### PR TITLE
Add flake8-coding

### DIFF
--- a/scripts/linting/requirements.in
+++ b/scripts/linting/requirements.in
@@ -13,3 +13,4 @@ flake8-commas
 flake8-blind-except
 flake8-builtins==1.0
 flake8-print
+flake8-coding

--- a/scripts/linting/requirements.txt
+++ b/scripts/linting/requirements.txt
@@ -6,6 +6,7 @@
 #
 flake8-blind-except==0.1.1
 flake8-builtins==1.0
+flake8-coding==1.3.0
 flake8-commas==2.0.0
 flake8-comprehensions==1.4.1
 flake8-debugger==3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ test=pytest
 [flake8]
 ignore=D401,D107,D202,D200,D204,C401,D413
 exclude=tests,migrations
+no-accept-encodings=true
 
 [mypy]
 ignore_missing_imports=true


### PR DESCRIPTION
Add flake8-coding to ban magic coding comments and enforce UTF-8 source file encoding.