### PR TITLE
Prometheus logger iterations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ COPY alembic.ini alembic.ini
 
 EXPOSE 2017
 
+ENV prometheus_multiproc_dir /tmp/routemaster/prometheus
+
 CMD ["routemaster", "--config-file=config.yaml", "serve"]

--- a/plugins/conftest.py
+++ b/plugins/conftest.py
@@ -1,9 +1,17 @@
 """Pytest conftest for plugin tests."""
 
-from routemaster.conftest import app, custom_app, custom_client
+from routemaster.conftest import (
+    app,
+    custom_app,
+    custom_client,
+    unused_tcp_port,
+    routemaster_serve_subprocess,
+)
 
 __all__ = (
     'app',
     'custom_app',
     'custom_client',
+    'unused_tcp_port',
+    'routemaster_serve_subprocess',
 )

--- a/plugins/conftest.py
+++ b/plugins/conftest.py
@@ -3,7 +3,6 @@
 from routemaster.conftest import (
     app,
     custom_app,
-    custom_client,
     unused_tcp_port,
     routemaster_serve_subprocess,
 )
@@ -11,7 +10,6 @@ from routemaster.conftest import (
 __all__ = (
     'app',
     'custom_app',
-    'custom_client',
     'unused_tcp_port',
     'routemaster_serve_subprocess',
 )

--- a/plugins/conftest.py
+++ b/plugins/conftest.py
@@ -1,7 +1,9 @@
 """Pytest conftest for plugin tests."""
 
-from routemaster.conftest import app
+from routemaster.conftest import app, custom_app, custom_client
 
 __all__ = (
     'app',
+    'custom_app',
+    'custom_client',
 )

--- a/plugins/routemaster-prometheus/README.md
+++ b/plugins/routemaster-prometheus/README.md
@@ -9,3 +9,14 @@ plugins:
       kwargs:
         path: /metrics
 ```
+
+This package is based on the official Python Promeutheus bindings in
+[`prometheus_client`](https://pypi.org/project/prometheus_client/). In order
+for that package to operate in a multithreaded program such as Routemaster,
+the environment variable `prometheus_multiproc_dir` must be set to a writeable
+directory for temporary files. It does not need to be backed up as nothing
+is persisted between application launches.
+
+This is already done for you in the `thread/routemaster` Docker image
+provided, but when deploying in a custom way you may wish to change this
+directory.

--- a/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
+++ b/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
@@ -9,8 +9,8 @@ import shutil
 import pathlib
 import contextlib
 from timeit import default_timer as timer
-from werkzeug.routing import NotFound, RequestRedirect, MethodNotAllowed
 
+from werkzeug.routing import NotFound, RequestRedirect, MethodNotAllowed
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     Counter,

--- a/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
+++ b/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
@@ -54,7 +54,7 @@ api_histogram = Histogram(
 api_counter = Counter(
     'routemaster_api_request_total',
     'Total number of API requests',
-    ('method', 'status'),
+    ('method', 'status', 'endpoint'),
 )
 
 
@@ -174,6 +174,7 @@ class PrometheusLogger(BaseLogger):
         api_counter.labels(
             method=environ.get('REQUEST_METHOD'),
             status=status,
+            endpoint=path,
         ).inc()
 
 

--- a/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
+++ b/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
@@ -4,65 +4,104 @@ Prometheus metrics exporter for Routemaster.
 This package provides a Routemaster logging plugin that interfaces to the
 Python Prometheus API, to export monitoring metrics to Prometheus.
 """
+import os
+import shutil
+import pathlib
 import contextlib
+from timeit import default_timer as timer
 
-from prometheus_client import Counter, CollectorRegistry
-from prometheus_flask_exporter import PrometheusMetrics
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    CollectorRegistry,
+    generate_latest,
+)
+import prometheus_client.core
+from prometheus_client.multiprocess import MultiProcessCollector
 
 from routemaster.logging import BaseLogger
+
+exceptions = Counter(
+    'exceptions',
+    "Exceptions logged",
+    ('type',),
+)
+
+cron_jobs_processed = Counter(
+    'cron_jobs_processed',
+    "Cron jobs processed",
+    ('fn_name', 'state_machine', 'state'),
+)
+
+feed_requests = Counter(
+    'feed_requests',
+    "Feed requests",
+    ('feed_url', 'state_machine', 'state', 'status_code'),
+)
+
+webhook_requests = Counter(
+    'webhook_requests',
+    "Webhook requests",
+    ('state_machine', 'state', 'status_code'),
+)
+
+api_histogram = Histogram(
+    'routemaster_api_request_duration_seconds',
+    'Routemaster API request duration in seconds',
+    ('method', 'endpoint', 'status'),
+)
+
+api_counter = Counter(
+    'routemaster_api_request_total',
+    'Total number of API requests',
+    ('method', 'status'),
+)
 
 
 class PrometheusLogger(BaseLogger):
     """Instruments Routemaster with Prometheus."""
 
-    def __init__(self, *args, path='/metrics'):
+    def __init__(
+        self,
+        *args,
+        path='/metrics',
+    ):
         self.path = path
-        self.registry = CollectorRegistry(auto_describe=True)
+        metrics_path = os.environ.get('prometheus_multiproc_dir')
 
-        self.exceptions = Counter(
-            'exceptions',
-            "Exceptions logged",
-            ('type',),
-            registry=self.registry,
-        )
+        if not metrics_path:
+            raise ValueError(
+                "PrometheusLogger requires the environment variable "
+                "`prometheus_multiproc_dir` to be set to a writeable "
+                "directory.",
+            )
 
-        self.cron_jobs_processed = Counter(
-            'cron_jobs_processed',
-            "Cron jobs processed",
-            ('fn_name', 'state_machine', 'state'),
-            registry=self.registry,
-        )
-
-        self.feed_requests = Counter(
-            'feed_requests',
-            "Feed requests",
-            ('feed_url', 'state_machine', 'state', 'status_code'),
-            registry=self.registry,
-        )
-
-        self.webhook_requests = Counter(
-            'webhook_requests',
-            "Webhook requests",
-            ('state_machine', 'state', 'status_code'),
-            registry=self.registry,
-        )
+        pathlib.Path(metrics_path).mkdir(parents=True, exist_ok=True)
+        _clear_directory(metrics_path)
 
         super().__init__(*args)
 
     def init_flask(self, flask_app):
         """Instrument Flask with Prometheus."""
-        self.metrics = PrometheusMetrics(
-            flask_app,
-            path=self.path,
-            registry=self.registry,
-        )
+
+        @flask_app.route(self.path)
+        def get_metrics():
+            registry = CollectorRegistry()
+            MultiProcessCollector(registry)
+            data = generate_latest(registry)
+            response_headers = [
+                ('Content-type', CONTENT_TYPE_LATEST),
+                ('Content-Length', str(len(data))),
+            ]
+            return data, 200, response_headers
 
     @contextlib.contextmanager
     def process_cron(self, state_machine, state, fn_name):
         """Send cron exceptions to Prometheus."""
-        with self.exceptions.labels(type='cron').count_exceptions():
+        with exceptions.labels(type='cron').count_exceptions():
             yield
-            self.cron_jobs_processed.labels(
+            cron_jobs_processed.labels(
                 fn_name=fn_name,
                 state_machine=state_machine.name,
                 state=state.name,
@@ -71,13 +110,13 @@ class PrometheusLogger(BaseLogger):
     @contextlib.contextmanager
     def process_webhook(self, state_machine, state):
         """Send webhook request exceptions to Prometheus."""
-        with self.exceptions.labels(type='webhook').count_exceptions():
+        with exceptions.labels(type='webhook').count_exceptions():
             yield
 
     @contextlib.contextmanager
     def process_feed(self, state_machine, state, feed_url):
         """Send feed request exceptions to Prometheus."""
-        with self.exceptions.labels(type='feed').count_exceptions():
+        with exceptions.labels(type='feed').count_exceptions():
             yield
 
     def feed_response(
@@ -102,8 +141,46 @@ class PrometheusLogger(BaseLogger):
         response,
     ):
         """Log webhook response with status code to Prometheus."""
-        self.webhook_requests.labels(
+        webhook_requests.labels(
             state_machine=state_machine.name,
             state=state.name,
             status_code=response.status_code,
         ).inc()
+
+    def process_request_started(self, environ):
+        """Start a timer."""
+        environ['_PROMETHEUS_REQUEST_TIMER'] = timer()
+
+    def process_request_finished(
+        self,
+        environ,
+        *,
+        status,
+        headers,
+        exc_info,
+    ):
+        """Log completed request metrics, given the timer we started."""
+        total_time = max(timer() - environ['_PROMETHEUS_REQUEST_TIMER'], 0)
+        path = environ.get('PATH_INFO', '')
+
+        if path == self.path:
+            return
+
+        api_histogram.labels(
+            method=environ.get('REQUEST_METHOD'),
+            endpoint=path,
+            status=status,
+        ).observe(total_time)
+
+        api_counter.labels(
+            method=environ.get('REQUEST_METHOD'),
+            status=status,
+        ).inc()
+
+
+def _clear_directory(path: pathlib.Path):
+    for root, dirs, files in os.walk(path):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))

--- a/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
+++ b/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
@@ -17,7 +17,6 @@ from prometheus_client import (
     CollectorRegistry,
     generate_latest,
 )
-import prometheus_client.core
 from prometheus_client.multiprocess import MultiProcessCollector
 
 from routemaster.logging import BaseLogger

--- a/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
+++ b/plugins/routemaster-prometheus/routemaster_prometheus/__init__.py
@@ -127,7 +127,7 @@ class PrometheusLogger(BaseLogger):
         response,
     ):
         """Log feed response with status code to Prometheus."""
-        self.feed_requests.labels(
+        feed_requests.labels(
             feed_url=feed_url,
             state_machine=state_machine.name,
             state=state.name,

--- a/plugins/routemaster-prometheus/setup.py
+++ b/plugins/routemaster-prometheus/setup.py
@@ -39,6 +39,5 @@ setup(
     install_requires=(
         'routemaster',
         'prometheus_client',
-        'prometheus_flask_exporter',
     ),
 )

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -59,7 +59,10 @@ def test_logger(app, klass, kwargs):
         with logger.process_webhook(state_machine, state):
             raise RuntimeError("Error must propagate")
 
-    wsgi_environ = {}
+    wsgi_environ = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/',
+    }
     logger.process_request_started(wsgi_environ)
     logger.process_request_finished(
         wsgi_environ,

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -115,7 +115,8 @@ def test_prometheus_logger_wipes_directory_on_startup(app):
 def test_prometheus_logger_metrics(routemaster_serve_subprocess):
     with routemaster_serve_subprocess() as (proc, port):
         while True:
-            if 'Booting worker' in proc.stdout.readline().decode('utf-8'):
+            out = proc.stdout.readline()
+            if 'Booting worker' in out.decode('utf-8'):
                 break
 
         # Populate metrics with a request
@@ -135,7 +136,8 @@ def test_prometheus_logger_metrics(routemaster_serve_subprocess):
 def test_prometheus_logger_ignores_metrics_path(routemaster_serve_subprocess):
     with routemaster_serve_subprocess() as (proc, port):
         while True:
-            if 'Booting worker' in proc.stdout.readline().decode('utf-8'):
+            out = proc.stdout.readline()
+            if 'Booting worker' in out.decode('utf-8'):
                 break
 
         # This should _not_ populate the metrics with any samples

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -115,7 +115,7 @@ def test_prometheus_logger_wipes_directory_on_startup(app):
 def test_prometheus_logger_metrics(routemaster_serve_subprocess):
     with routemaster_serve_subprocess() as (proc, port):
         while True:
-            if 'Booting worker' in proc.stderr.readline().decode('utf-8'):
+            if 'Booting worker' in proc.stdout.readline().decode('utf-8'):
                 break
 
         # Populate metrics with a request
@@ -135,7 +135,7 @@ def test_prometheus_logger_metrics(routemaster_serve_subprocess):
 def test_prometheus_logger_ignores_metrics_path(routemaster_serve_subprocess):
     with routemaster_serve_subprocess() as (proc, port):
         while True:
-            if 'Booting worker' in proc.stderr.readline().decode('utf-8'):
+            if 'Booting worker' in proc.stdout.readline().decode('utf-8'):
                 break
 
         # This should _not_ populate the metrics with any samples

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -68,6 +68,7 @@ def test_logger(app, klass, kwargs):
         with logger.process_webhook(state_machine, state):
             raise RuntimeError("Error must propagate")
 
+    # Test valid request
     wsgi_environ = {
         'REQUEST_METHOD': 'GET',
         'PATH_INFO': '/',
@@ -76,6 +77,32 @@ def test_logger(app, klass, kwargs):
     logger.process_request_finished(
         wsgi_environ,
         status=200,
+        headers={},
+        exc_info=None,
+    )
+
+    # Test failed request
+    wsgi_environ_failed = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/',
+    }
+    logger.process_request_started(wsgi_environ_failed)
+    logger.process_request_finished(
+        wsgi_environ_failed,
+        status=200,
+        headers={},
+        exc_info=(RuntimeError, RuntimeError('Test exception'), None),
+    )
+
+    # Test with invalid path
+    wsgi_environ_invalid_path = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/non-existent',
+    }
+    logger.process_request_started(wsgi_environ_invalid_path)
+    logger.process_request_finished(
+        wsgi_environ_invalid_path,
+        status=404,
         headers={},
         exc_info=None,
     )

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -36,6 +36,11 @@ def test_logger(app, klass, kwargs):
     feed_url = 'https://localhost'
 
     server = Flask('test_server')
+
+    @server.route('/')
+    def root():
+        return 'Ok', 200
+
     logger.init_flask(server)
 
     with logger.process_cron(state_machine, state, 'test_cron'):

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 from typing import Any, Dict, Type, Tuple, Iterable
 
 import pytest
@@ -79,3 +81,20 @@ def test_logger(app, klass, kwargs):
     response = requests.Response()
     logger.webhook_response(state_machine, state, response)
     logger.feed_response(state_machine, state, feed_url, response)
+
+
+def test_prometheus_logger_wipes_directory_on_startup(app):
+    tmp = pathlib.Path(os.environ['prometheus_multiproc_dir'])
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    filepath = tmp / 'foo.txt'
+    dirpath = tmp / 'subdir'
+
+    dirpath.mkdir(parents=True, exist_ok=True)
+    with filepath.open('w') as f:
+        f.write('Hello, world')
+
+    PrometheusLogger(app.config)
+
+    assert not filepath.exists()
+    assert not dirpath.exists()

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -7,7 +7,9 @@ import requests
 from flask import Flask
 from routemaster_sentry import SentryLogger
 from routemaster_prometheus import PrometheusLogger
+from prometheus_client.parser import text_string_to_metric_families
 
+from routemaster.config import LoggingPluginConfig
 from routemaster.logging import BaseLogger, SplitLogger
 
 SENTRY_KWARGS = {
@@ -106,3 +108,73 @@ def test_prometheus_logger_wipes_directory_on_startup(app):
 
     assert not filepath.exists()
     assert not dirpath.exists()
+
+
+def test_prometheus_logger_metrics(custom_app, custom_client):
+    test_metrics_path = '/test_prometheus_logger_metrics'
+    app = custom_app(
+        logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='routemaster_prometheus:PrometheusLogger',
+                kwargs={'path': test_metrics_path},
+            ),
+        ],
+    )
+    client = custom_client(app)
+
+    wsgi_environ = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/',
+    }
+    app.logger.process_request_started(wsgi_environ)
+    app.logger.process_request_finished(
+        wsgi_environ,
+        status=200,
+        headers={},
+        exc_info=None,
+    )
+
+    metrics_response = client.get(test_metrics_path)
+    metrics_data = metrics_response.data.decode('utf-8')
+    metric_families = list(text_string_to_metric_families(metrics_data))
+    samples = [y for x in metric_families for y in x.samples]
+
+    assert (
+        'routemaster_api_request_duration_seconds_count',
+        {'method': 'GET', 'status': '200', 'endpoint': '/'},
+        1.0,
+    ) in samples
+
+
+def test_prometheus_logger_ignores_metrics_path(custom_app, custom_client):
+    test_metrics_path = '/test_prometheus_logger_ignores_metrics_path'
+    app = custom_app(
+        logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='routemaster_prometheus:PrometheusLogger',
+                kwargs={'path': test_metrics_path},
+            ),
+        ],
+    )
+    client = custom_client(app)
+
+    metrics_response = client.get(test_metrics_path)
+    metrics_data = metrics_response.data.decode('utf-8')
+    metric_families = list(text_string_to_metric_families(metrics_data))
+    samples = [y for x in metric_families for y in x.samples]
+
+    assert (
+        'routemaster_api_request_duration_seconds_count',
+        {'method': 'GET', 'status': '200', 'endpoint': test_metrics_path},
+        1.0,
+    ) not in samples
+
+
+def test_prometheus_logger_validates_metrics_path(app):
+    orig = os.environ['prometheus_multiproc_dir']
+    os.environ['prometheus_multiproc_dir'] = ''
+
+    with pytest.raises(ValueError):
+        PrometheusLogger(app.config)
+
+    os.environ['prometheus_multiproc_dir'] = orig

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -1,5 +1,6 @@
 """Global test setup and fixtures."""
 
+import io
 import os
 import re
 import json
@@ -536,15 +537,19 @@ def routemaster_serve_subprocess(unused_tcp_port):
     def _inner():
         try:
             proc = subprocess.Popen(
-                f'routemaster --config-file=example.yaml serve '
-                f'--bind 127.0.0.1:{unused_tcp_port}',
-                shell=True,
+                [
+                    'routemaster',
+                    '--config-file=example.yaml',
+                    'serve',
+                    '--bind',
+                    f'127.0.0.1:{unused_tcp_port}',
+                ],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
             )
             yield proc, unused_tcp_port
         finally:
-            proc.kill()
+            proc.terminate()
 
     return _inner

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -263,11 +263,18 @@ class TestClientResponse(BaseResponse):
 
 
 @pytest.fixture()
-def client():
+def client(custom_app=None):
     """Create a werkzeug test client."""
-    _app = app()
+    _app = app() if custom_app is None else custom_app
     server.config.app = _app
+    _app.logger.init_flask(server)
     return Client(wrap_application(_app, server), TestClientResponse)
+
+
+@pytest.fixture()
+def custom_client():
+    """Return the client fixture directly so that we can modify the app."""
+    return client
 
 
 @pytest.fixture()

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -40,7 +40,7 @@ from routemaster.config import (
 )
 from routemaster.server import server
 from routemaster.context import Context
-from routemaster.logging import BaseLogger
+from routemaster.logging import BaseLogger, SplitLogger, register_loggers
 from routemaster.webhooks import (
     WebhookResult,
     webhook_runner_for_state_machine,
@@ -236,7 +236,7 @@ class TestApp(App):
     def __init__(self, config):
         self.config = config
         self.session_used = False
-        self.logger = mock.MagicMock()
+        self.logger = SplitLogger(config, loggers=register_loggers(config))
         self._session = None
         self._needs_rollback = False
         self._current_session = None

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -1,6 +1,5 @@
 """Global test setup and fixtures."""
 
-import io
 import os
 import re
 import json
@@ -535,6 +534,15 @@ def routemaster_serve_subprocess(unused_tcp_port):
 
     @contextlib.contextmanager
     def _inner():
+        env = os.environ.copy()
+        env.update({
+            'DB_HOST': os.environ.get('PG_HOST', 'localhost'),
+            'DB_PORT': os.environ.get('PG_PORT', '5432'),
+            'DB_NAME': os.environ.get('PG_DB', 'routemaster_test'),
+            'DB_USER': os.environ.get('PG_USER', ''),
+            'DB_PASS': os.environ.get('PG_PASS', ''),
+        })
+
         try:
             proc = subprocess.Popen(
                 [
@@ -544,6 +552,7 @@ def routemaster_serve_subprocess(unused_tcp_port):
                     '--bind',
                     f'127.0.0.1:{unused_tcp_port}',
                 ],
+                env=env,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -274,12 +274,6 @@ def client(custom_app=None):
 
 
 @pytest.fixture()
-def custom_client():
-    """Return the client fixture directly so that we can modify the app."""
-    return client
-
-
-@pytest.fixture()
 def app(**kwargs):
     """Create an `App` config object for testing."""
     return TestApp(Config(

--- a/routemaster/logging/base.py
+++ b/routemaster/logging/base.py
@@ -28,14 +28,19 @@ class BaseLogger:
         """Wraps the processing of a webhook for logging purposes."""
         yield
 
-    @contextlib.contextmanager
-    def process_request(self, environ):
-        """
-        Wraps the processing of a request for logging purposes.
+    def process_request_started(self, environ):
+        """Request started."""
+        pass
 
-        Note, this wraps at the WSGI level, not the Flask level.
-        """
-        yield
+    def process_request_finished(
+        self,
+        environ,
+        status,
+        headers,
+        exc_info,
+    ):
+        """Completes the processing of a request."""
+        pass
 
     def webhook_response(
         self,

--- a/routemaster/logging/python_logger.py
+++ b/routemaster/logging/python_logger.py
@@ -44,15 +44,20 @@ class PythonLogger(BaseLogger):
             f"in {state_machine.name} in {duration:.2f} seconds",
         )
 
-    @contextlib.contextmanager
-    def process_request(self, environ):
+    def process_request_finished(
+        self,
+        environ,
+        *,
+        status,
+        headers,
+        exc_info,
+    ):
         """Process a web request and log some basic info about it."""
-        self.info("{method} {path}".format(
+        self.info("{method} {path} {status}".format(
             method=environ.get('REQUEST_METHOD'),
             path=environ.get('PATH_INFO'),
+            status=status,
         ))
-
-        yield
 
     def __getattr__(self, name):
         """Fall back to the logger API."""

--- a/routemaster/logging/split_logger.py
+++ b/routemaster/logging/split_logger.py
@@ -27,6 +27,8 @@ class SplitLogger(BaseLogger):
 
             'webhook_response',
             'feed_response',
+            'process_request_started',
+            'process_request_finished',
         ):
             setattr(self, fn, functools.partial(self._log_all, fn))
 
@@ -34,7 +36,6 @@ class SplitLogger(BaseLogger):
             'process_cron',
             'process_webhook',
             'process_feed',
-            'process_request',
         ):
             setattr(self, fn, functools.partial(self._log_all_ctx, fn))
 

--- a/routemaster/logging/tests/test_loggers.py
+++ b/routemaster/logging/tests/test_loggers.py
@@ -53,12 +53,14 @@ def test_logger(app, klass, kwargs):
         with logger.process_webhook(state_machine, state):
             raise RuntimeError("Error must propagate")
 
-    with logger.process_request({}):
-        pass
-
-    with pytest.raises(RuntimeError):
-        with logger.process_request({}):
-            raise RuntimeError("Error must propagate")
+    wsgi_environ = {}
+    logger.process_request_started(wsgi_environ)
+    logger.process_request_finished(
+        wsgi_environ,
+        status=200,
+        headers={},
+        exc_info=None,
+    )
 
     logger.debug("test")
     logger.info("test")

--- a/routemaster/logging/tests/test_loggers.py
+++ b/routemaster/logging/tests/test_loggers.py
@@ -53,7 +53,10 @@ def test_logger(app, klass, kwargs):
         with logger.process_webhook(state_machine, state):
             raise RuntimeError("Error must propagate")
 
-    wsgi_environ = {}
+    wsgi_environ = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/',
+    }
     logger.process_request_started(wsgi_environ)
     logger.process_request_finished(
         wsgi_environ,

--- a/routemaster/logging/tests/test_logging_plugin_system.py
+++ b/routemaster/logging/tests/test_logging_plugin_system.py
@@ -43,72 +43,60 @@ def test_loads_plugin_from_callable(custom_app):
 
 
 def test_raises_for_invalid_plugin_base_class(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='logger_plugin:InvalidLogger',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='logger_plugin:InvalidLogger',
+                kwargs={},
+            ),
+        ])
 
 
 def test_raises_for_plugin_with_invalid_constructor(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='logger_plugin:NoArgsLogger',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='logger_plugin:NoArgsLogger',
+                kwargs={},
+            ),
+        ])
 
 
 def test_raises_for_plugin_not_on_pythonpath(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='non_existent:DoesNotExistLogger',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='non_existent:DoesNotExistLogger',
+                kwargs={},
+            ),
+        ])
 
 
 def test_raises_for_plugin_in_invalid_format(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='logger_plugin.TestLogger',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='logger_plugin.TestLogger',
+                kwargs={},
+            ),
+        ])
 
 
 def test_raises_for_plugin_non_existent_class(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='logger_plugin:DoesNotExistLogger',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='logger_plugin:DoesNotExistLogger',
+                kwargs={},
+            ),
+        ])
 
 
 def test_raises_for_not_callable_value(custom_app):
-    app = custom_app(logging_plugins=[
-        LoggingPluginConfig(
-            dotted_path='logger_plugin:NOT_CALLABLE',
-            kwargs={},
-        ),
-    ])
-
     with pytest.raises(PluginConfigurationException):
-        register_loggers(app.config)
+        custom_app(logging_plugins=[
+            LoggingPluginConfig(
+                dotted_path='logger_plugin:NOT_CALLABLE',
+                kwargs={},
+            ),
+        ])

--- a/routemaster/middleware.py
+++ b/routemaster/middleware.py
@@ -63,7 +63,7 @@ def logging_middleware(app: App, wsgi: WSGICallable) -> WSGICallable:
             headers: Dict[str, str],
             exc_info: Optional[Any] = None,
         ) -> None:
-            kwargs['status'] = status
+            kwargs['status'] = status.split()[0]
             kwargs['headers'] = headers
             kwargs['exc_info'] = exc_info
             start_response(status, headers, exc_info)

--- a/routemaster/state_machine/api.py
+++ b/routemaster/state_machine/api.py
@@ -245,5 +245,6 @@ def process_cron(
                     label=label,
                 )
 
-            if could_progress:
-                process_transitions(app, label)
+            with app.new_session():
+                if could_progress:
+                    process_transitions(app, label)

--- a/routemaster/state_machine/tests/test_transitions.py
+++ b/routemaster/state_machine/tests/test_transitions.py
@@ -11,7 +11,7 @@ def test_cannot_infinite_loop(app, create_label, set_metadata):
     with app.new_session():
         process_transitions(app, label)
 
-    app.logger.warn.assert_called_once()
+    app.logger.warning.assert_called_once()
 
 
 def test_stops_on_delete(app, create_label, set_metadata):

--- a/routemaster/state_machine/tests/test_transitions.py
+++ b/routemaster/state_machine/tests/test_transitions.py
@@ -5,6 +5,7 @@ from routemaster.state_machine.transitions import process_transitions
 
 
 def test_cannot_infinite_loop(app, create_label, set_metadata):
+    app.logger = mock.Mock()
     label = create_label('foo', 'test_infinite_machine', {})
     set_metadata(label, {'should_progress': True})
 

--- a/routemaster/state_machine/transitions.py
+++ b/routemaster/state_machine/transitions.py
@@ -65,7 +65,7 @@ def process_transitions(app: App, label: LabelRef) -> None:
         num_transitions += 1
 
         if num_transitions == MAX_TRANSITIONS:
-            app.logger.warn(textwrap.dedent(
+            app.logger.warning(textwrap.dedent(
                 f"""
                 Label {label}
                 hit the maximum number of transitions allowed in one go. This

--- a/routemaster/tests/test_webhook_runner.py
+++ b/routemaster/tests/test_webhook_runner.py
@@ -60,8 +60,9 @@ def test_requests_webhook_runner_handles_other_failure_modes_as_retry(status):
 
 @httpretty.activate
 def test_requests_webhook_runner_handles_timeout_as_retry():
-    def raise_retry():
+    def raise_retry(*args, **kwargs):
         raise requests.ReadTimeout()
+
     httpretty.register_uri(
         httpretty.POST,
         'http://example.com/',

--- a/scripts/testing/requirements.txt
+++ b/scripts/testing/requirements.txt
@@ -1,6 +1,7 @@
 tox
 pytest
 pytest-cov
+pytest-env
 pytest-randomly
 pytest-faulthandler
 freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,5 @@ skip=routemaster/migrations
 
 [tool:pytest]
 python_paths=test_data/plugins/
+env =
+    prometheus_multiproc_dir=/tmp/routemaster-tests/prometheus

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ passenv=
     PG_PORT
     PG_DB
     PG_USER
+setenv =
+    prometheus_multiproc_dir={envtmpdir}
 commands =
     mkdir -p build/results
     mkdir -p build/artifacts


### PR DESCRIPTION
This fixes the prometheus logger in a multithreaded environment, and iterates the logging plugin API to be able to provide more useful information.

Unfortunately, `test_prometheus_logger_metrics` fails to find any metrics, if it is run _after_ `test_logger[PrometheusLogger-kwargs1]` or `test_logger[SplitLogger-kwargs1]` (which both use the `PrometheusLogger`). I haven't resolved this issue yet.