### PR TITLE
Add type stubs for the sqlalchemy models

### DIFF
--- a/routemaster/db/model.py
+++ b/routemaster/db/model.py
@@ -53,6 +53,8 @@ sync_label_updated_column = DDL(
 class Label(Base):
     """A single label including context."""
 
+    # Note: type annotations for this class are provided by a stubs file
+
     __table__ = Table(
         'labels',
         metadata,
@@ -81,6 +83,8 @@ class Label(Base):
 
 class History(Base):
     """A single historical state transition of a label."""
+
+    # Note: type annotations for this class are provided by a stubs file
 
     __table__ = Table(
         'history',

--- a/routemaster/db/model.pyi
+++ b/routemaster/db/model.pyi
@@ -1,0 +1,61 @@
+import datetime
+from typing import Any, Dict, List, Union, Optional
+
+from sqlalchemy import MetaData
+
+
+# Imperfect JSON type (see https://github.com/python/typing/issues/182)
+_JSON = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+
+
+metadata: MetaData
+
+
+class Label:
+    name: str
+    state_machine: str
+    metadata: _JSON
+    metadata_triggers_processed: bool
+    deleted: bool
+    updated: datetime.datetime
+
+    history: List['History']
+
+    def __init__(
+        self,
+        *,
+        name: str=...,
+        state_machine: str=...,
+        metadata: _JSON=...,
+        metadata_triggers_processed: bool=...,
+        deleted: bool=...,
+        updated: datetime.datetime=...,
+        history: List['History']=...,
+    ) -> None: ...
+
+
+class History:
+    id: int
+
+    label_name: str
+    label_state_machine: str
+    created: datetime.datetime
+    forced: bool
+
+    old_state: Optional[str]
+    new_state: Optional[str]
+
+    label: Label
+
+    def __init__(
+        self,
+        *,
+        id: int=...,
+        label_name: str=...,
+        label_state_machine: str=...,
+        created: datetime.datetime=...,
+        forced: bool=...,
+        old_state: Optional[str]=...,
+        new_state: Optional[str]=...,
+        label: Label=...,
+    ) -> None: ...

--- a/routemaster/state_machine/utils.py
+++ b/routemaster/state_machine/utils.py
@@ -67,7 +67,11 @@ def get_current_history(app: App, label: LabelRef) -> History:
         label_name=label.name,
         label_state_machine=label.state_machine,
     ).order_by(
-        History.id.desc(),
+        # Our model type stubs define the `id` attribute as `int`, yet
+        # sqlalchemy actually allows the attribute to be used for ordering like
+        # this; ignore the type check here specifically rather than complicate
+        # our type definitions.
+        History.id.desc(),  # type: ignore
     ).first()
 
     if history_entry is None:
@@ -155,7 +159,11 @@ def _labels_in_state(
         History.label_name,
         History.new_state,
         func.row_number().over(
-            order_by=History.id.desc(),
+            # Our model type stubs define the `id` attribute as `int`, yet
+            # sqlalchemy actually allows the attribute to be used for ordering
+            # like this; ignore the type check here specifically rather than
+            # complicate our type definitions.
+            order_by=History.id.desc(),  # type: ignore
             partition_by=History.label_name,
         ).label('rank'),
     ).filter_by(


### PR DESCRIPTION
This means that we get real type checking for the model types, rather than the `Any` checking which we were previously getting.

This currently errors due to the issue which #68 fixes (though amazingly shows _no other issues_), so I consider this blocked until that merges.