### PR TITLE
Validate top level lookups

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -40,7 +40,7 @@ state_machines:
         triggers:
           - metadata: metadata.recs.has_first_recommendations
         exit_condition: >
-          recs.has_first_recommendations and
+          metadata.recs.has_first_recommendations and
           (feeds.jacquard.has_redesigned_first_two_drip_emails is defined)
         next:
           type: context
@@ -66,7 +66,7 @@ state_machines:
         triggers:
           - time: 18h30m
         exit_condition: >
-          12h has passed since current_state.entered
+          12h has passed since history.entered_state
         next:
           type: constant
           state: send_browse_email

--- a/routemaster/config/loader.py
+++ b/routemaster/config/loader.py
@@ -10,6 +10,7 @@ import jsonschema
 import pkg_resources
 import jsonschema.exceptions
 
+from routemaster.text_utils import join_comma_or
 from routemaster.config.model import (
     Gate,
     State,
@@ -182,9 +183,10 @@ def _validate_context_lookups(
         location, *rest = lookup.split('.')
 
         if location not in VALID_TOP_LEVEL:
+            valid_top_level = join_comma_or(f"'{x}'" for x in VALID_TOP_LEVEL)
             raise ConfigError(
                 f"Invalid context lookup at {'.'.join(path)}: key {lookup} "
-                f"must start with one of 'feeds', 'history' or 'metadata'.",
+                f"must start with one of {valid_top_level}.",
             )
 
         if location == 'feeds':

--- a/routemaster/config/loader.py
+++ b/routemaster/config/loader.py
@@ -192,7 +192,7 @@ def _validate_context_lookups(
         if location == 'feeds':
             feed_name = rest[0]
             if feed_name not in feed_names:
-                valid_names = ", ".join(f"'{x}'" for x in feed_names)
+                valid_names = join_comma_or(f"'{x}'" for x in feed_names)
                 raise ConfigError(
                     f"Invalid feed name at {'.'.join(path)}: key {lookup} "
                     f"references unknown feed '{feed_name}' (configured "

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -188,6 +188,16 @@ def test_raises_for_invalid_top_level_context_name_in_exit_condition():
         ))
 
 
+def test_raises_for_invalid_feed_name_in_lookup():
+    with assert_config_error(
+        "Invalid feed name at "
+        "state_machines.the_workflow.states.0.exit_condition: key "
+        "feeds.nope.has_option_b references unknown feed 'nope' (configured "
+        "feeds are: 'jacquard')",
+    ):
+        load_config(yaml_data('invalid_feed_name_in_exit_condition'))
+
+
 def test_raises_for_action_and_gate_state():
     with assert_config_error("Could not validate config file against schema."):
         load_config(yaml_data('action_and_gate_invalid'))

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -113,7 +113,7 @@ def test_realistic_config():
                         name='stage2',
                         triggers=[],
                         next_states=ContextNextStates(
-                            path='foo.bar',
+                            path='metadata.foo.bar',
                             destinations=[
                                 ContextNextStatesOption(
                                     state='stage3',
@@ -127,7 +127,7 @@ def test_realistic_config():
                             default='end',
                         ),
                         exit_condition=ExitConditionProgram(
-                            'foo.bar is defined',
+                            'metadata.foo.bar is defined',
                         ),
                     ),
                     Action(
@@ -164,6 +164,28 @@ def test_realistic_config():
     )
     with reset_environment():
         assert load_config(data) == expected
+
+
+def test_raises_for_invalid_top_level_context_name_in_path():
+    with assert_config_error(
+        "Invalid context lookup at "
+        "state_machines.the_workflow.states.0.next.path: key "
+        "jacquard.has_option_b must start with one of 'feeds', 'history' or "
+        "'metadata'.",
+    ):
+        load_config(yaml_data('invalid_top_level_context_name_in_path'))
+
+
+def test_raises_for_invalid_top_level_context_name_in_exit_condition():
+    with assert_config_error(
+        "Invalid context lookup at "
+        "state_machines.the_workflow.states.0.exit_condition: key "
+        "jacquard.has_option_b must start with one of 'feeds', 'history' or "
+        "'metadata'.",
+    ):
+        load_config(yaml_data(
+            'invalid_top_level_context_name_in_exit_condition',
+        ))
 
 
 def test_raises_for_action_and_gate_state():
@@ -288,7 +310,7 @@ def test_environment_variables_override_config_file_for_database_config():
                         name='stage2',
                         triggers=[],
                         next_states=ContextNextStates(
-                            path='foo.bar',
+                            path='metadata.foo.bar',
                             destinations=[
                                 ContextNextStatesOption(
                                     state='stage3',
@@ -302,7 +324,7 @@ def test_environment_variables_override_config_file_for_database_config():
                             default='end',
                         ),
                         exit_condition=ExitConditionProgram(
-                            'foo.bar is defined',
+                            'metadata.foo.bar is defined',
                         ),
                     ),
                     Action(

--- a/routemaster/context.py
+++ b/routemaster/context.py
@@ -38,6 +38,8 @@ class Context(object):
         location, *rest = path
 
         try:
+            # Changing this mapping? Also change config validation in
+            # `routemaster.config.loader._validate_context_lookups`
             return {
                 'metadata': self._lookup_metadata,
                 'feeds': self._lookup_feed_data,

--- a/routemaster/tests/test_layering.py
+++ b/routemaster/tests/test_layering.py
@@ -31,6 +31,7 @@ DEPENDENCIES = (
 
     ('config', 'exit_conditions'),
     ('config', 'context'),
+    ('config', 'text_utils'),
     ('config', 'utils'),
     ('db', 'config'),
 

--- a/routemaster/tests/test_text_utils.py
+++ b/routemaster/tests/test_text_utils.py
@@ -1,0 +1,28 @@
+from pytest import raises
+
+from routemaster.text_utils import join_comma_or
+
+
+def test_join_comma_or_no_items():
+    with raises(ValueError):
+        join_comma_or([])
+
+
+def test_join_comma_or_single_item():
+    actual = join_comma_or(['item'])
+    assert actual == 'item'
+
+
+def test_join_comma_or_two_items():
+    actual = join_comma_or(['a', 'b'])
+    assert actual == 'a or b'
+
+
+def test_join_comma_or_three_items():
+    actual = join_comma_or(['a', 'b', 'c'])
+    assert actual == 'a, b or c'
+
+
+def test_join_comma_or_four_items():
+    actual = join_comma_or(['a', '4', 'b', 'c'])
+    assert actual == 'a, 4, b or c'

--- a/routemaster/text_utils.py
+++ b/routemaster/text_utils.py
@@ -1,0 +1,15 @@
+"""Shared text utilities."""
+from typing import Iterable
+
+
+def join_comma_or(items: Iterable[str]) -> str:
+    """Join strings with commas and 'or'."""
+    if not items:
+        raise ValueError("No items to join")
+
+    *rest, last = items
+
+    if not rest:
+        return last
+
+    return f"{', '.join(rest)} or {last}"

--- a/test_data/invalid_feed_name_in_exit_condition.yaml
+++ b/test_data/invalid_feed_name_in_exit_condition.yaml
@@ -7,5 +7,6 @@ state_machines:
       - gate: choice
         triggers:
           - event: entry
-        # This should be `feeds.jacquard.has_option_b`
+        # This exit condition should error as it has an invalid feed name (it
+        # should be `feeds.jacquard.has_option_b`)
         exit_condition: feeds.nope.has_option_b

--- a/test_data/invalid_feed_name_in_exit_condition.yaml
+++ b/test_data/invalid_feed_name_in_exit_condition.yaml
@@ -1,0 +1,11 @@
+state_machines:
+  the_workflow:
+    feeds:
+      - name: jacquard
+        url: http://localhost:1212/<label_id>
+    states:
+      - gate: choice
+        triggers:
+          - event: entry
+        # This should be `feeds.jacquard.has_option_b`
+        exit_condition: feeds.nope.has_option_b

--- a/test_data/invalid_top_level_context_name_in_exit_condition.yaml
+++ b/test_data/invalid_top_level_context_name_in_exit_condition.yaml
@@ -7,5 +7,6 @@ state_machines:
       - gate: choice
         triggers:
           - event: entry
-        # This should be `feeds.jacquard.has_option_b`
+        # This exit condition should error because it is missing the `feeds`
+        # prefix (the correct spelling would be `feeds.jacquard.has_option_b`)
         exit_condition: jacquard.has_option_b

--- a/test_data/invalid_top_level_context_name_in_exit_condition.yaml
+++ b/test_data/invalid_top_level_context_name_in_exit_condition.yaml
@@ -1,0 +1,11 @@
+state_machines:
+  the_workflow:
+    feeds:
+      - name: jacquard
+        url: http://localhost:1212/<label_id>
+    states:
+      - gate: choice
+        triggers:
+          - event: entry
+        # This should be `feeds.jacquard.has_option_b`
+        exit_condition: jacquard.has_option_b

--- a/test_data/invalid_top_level_context_name_in_path.yaml
+++ b/test_data/invalid_top_level_context_name_in_path.yaml
@@ -10,7 +10,8 @@ state_machines:
         exit_condition: true
         next:
           type: context
-          # This should be `feeds.jacquard.has_option_b`
+          # This path should error because it is missing the `feeds` prefix (the
+          # correct spelling would be `feeds.jacquard.has_option_b`)
           path: jacquard.has_option_b
           default: option_a
           destinations:

--- a/test_data/invalid_top_level_context_name_in_path.yaml
+++ b/test_data/invalid_top_level_context_name_in_path.yaml
@@ -1,0 +1,24 @@
+state_machines:
+  the_workflow:
+    feeds:
+      - name: jacquard
+        url: http://localhost:1212/<label_id>
+    states:
+      - gate: choice
+        triggers:
+          - event: entry
+        exit_condition: true
+        next:
+          type: context
+          # This should be `feeds.jacquard.has_option_b`
+          path: jacquard.has_option_b
+          default: option_a
+          destinations:
+            - value: true
+              state: option_b
+
+      - gate: option_a
+        exit_condition: false
+
+      - gate: option_b
+        exit_condition: false

--- a/test_data/realistic.yaml
+++ b/test_data/realistic.yaml
@@ -22,10 +22,10 @@ state_machines:
       - gate: stage2
         triggers: []
         exit_condition: >
-          foo.bar is defined
+          metadata.foo.bar is defined
         next:
           type: context
-          path: foo.bar
+          path: metadata.foo.bar
           default: end
           destinations:
             - state: stage3


### PR DESCRIPTION
Fixes #45 so that configs with lookups which are wrong in ways which we can trivially detect do indeed error.

This doesn't handle properties referenced in exit conditions, which I've since noticed are also fairly constant and which we could probably validate, though I suspect those deserve a slightly different approach.