### PR TITLE
Switch from PyYAML to ruamel.yaml

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -4,7 +4,7 @@ Development interactive script.
 Use with `python -i dev.py` for a useful interactive shell.
 """
 
-import yaml
+from ruamel import yaml
 
 from routemaster.db import *  # noqa: F403, F401
 from routemaster.app import App

--- a/dev.py
+++ b/dev.py
@@ -18,7 +18,7 @@ def app_from_config(config_path):
     By default, will use the example.yaml file.
     """
     with open(config_path, 'r') as f:
-        config = load_config(yaml.load(f))
+        config = load_config(yaml.safe_load(f))
 
     class InteractiveApp(App):
         """

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -29,7 +29,7 @@ def main(ctx, config_file):
     logging.getLogger('schedule').setLevel(logging.CRITICAL)
 
     try:
-        config = load_config(yaml.load(config_file))
+        config = load_config(yaml.safe_load(config_file))
     except ConfigError:
         logger.exception("Configuration Error")
         click.get_current_context().exit(1)

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -1,7 +1,7 @@
 """CLI handling for `routemaster`."""
 import logging
 
-import yaml
+from ruamel import yaml
 import click
 
 from routemaster.app import App

--- a/routemaster/config/loader.py
+++ b/routemaster/config/loader.py
@@ -71,7 +71,7 @@ def _schema_validate(config: Yaml) -> None:
         'routemaster.config',
         'schema.yaml',
     ).decode('utf-8')
-    schema_yaml = yaml.load(schema_raw)
+    schema_yaml = yaml.safe_load(schema_raw)
 
     try:
         jsonschema.validate(config, schema_yaml)

--- a/routemaster/config/loader.py
+++ b/routemaster/config/loader.py
@@ -5,7 +5,7 @@ import re
 import datetime
 from typing import Any, Dict, List, Optional
 
-import yaml
+from ruamel import yaml
 import jsonschema
 import pkg_resources
 import jsonschema.exceptions

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -37,7 +37,7 @@ def reset_environment():
 
 def yaml_data(name: str):
     with open(f'test_data/{name}.yaml') as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 @contextlib.contextmanager
@@ -372,7 +372,7 @@ def test_example_config_loads():
 
     assert example_yaml.exists(), "Example file is missing! (is this test set up correctly?)"
 
-    example_config = load_config(yaml.load(example_yaml.read_text()))
+    example_config = load_config(yaml.safe_load(example_yaml.read_text()))
 
     # Some basic assertions that we got the right thing loaded
     assert list(example_config.state_machines.keys()) == ['user_lifecycle']

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -5,7 +5,7 @@ import contextlib
 from pathlib import Path
 from unittest import mock
 
-import yaml
+from ruamel import yaml
 import pytest
 
 from routemaster.config import (

--- a/routemaster/tests/test_validation.py
+++ b/routemaster/tests/test_validation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import yaml
+from ruamel import yaml
 import pytest
 
 from routemaster.config import (

--- a/routemaster/tests/test_validation.py
+++ b/routemaster/tests/test_validation.py
@@ -216,7 +216,7 @@ def test_example_config_is_valid(app):
 
     assert example_yaml.exists(), "Example file is missing! (is this test set up correctly?)"
 
-    example_config = load_config(yaml.load(example_yaml.read_text()))
+    example_config = load_config(yaml.safe_load(example_yaml.read_text()))
 
     # quick check that we've loaded the config we expect
     assert list(example_config.state_machines.keys()) == ['user_lifecycle']

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 
     install_requires=(
         'click',
-        'pyyaml',
+        'ruamel.yaml',
         'jsonschema >=2.6',
         'flask',
         'psycopg2',


### PR DESCRIPTION
[`ruamel.yaml`][ruamel] is a more modern fork of PyYAML, which:

1. Uses YAML 1.3
2. Has some neat round-tripping functionality,
3. Is regularly maintained,
4. Isn't using deprecated APIs which are due to break.

[ruamel]: https://yaml.readthedocs.io/en/latest/overview.html