### PR TITLE
Always propagate exceptions out of the Flask app

### DIFF
--- a/routemaster/server/endpoints.py
+++ b/routemaster/server/endpoints.py
@@ -13,6 +13,7 @@ from routemaster.state_machine import (
 )
 
 server = Flask('routemaster')
+server.config['PROPAGATE_EXCEPTIONS'] = True
 
 
 @server.route('/', methods=['GET'])

--- a/routemaster/server/tests/test_endpoints.py
+++ b/routemaster/server/tests/test_endpoints.py
@@ -339,8 +339,3 @@ def test_update_label_410_for_deleted_label(
         content_type='application/json',
     )
     assert response.status_code == 410
-
-
-def test_check_loggers(client):
-    response = client.get('/check-loggers')
-    assert response.status_code == 500

--- a/routemaster/server/tests/test_propagate_exceptions.py
+++ b/routemaster/server/tests/test_propagate_exceptions.py
@@ -1,0 +1,13 @@
+from routemaster.server import server
+
+
+def test_propagate_exceptions_is_enabled():
+    """
+    Exception propagation is enabled in the Flask instance.
+
+    This is required for middleware to be able to correctly process errors on
+    500s (including, for instance, rolling back transactions).
+    """
+    # We check this at the config level, rather than the property, because
+    # the property is always true in test mode.
+    assert server.config['PROPAGATE_EXCEPTIONS'] is True


### PR DESCRIPTION
This behaviour is required for correctness. Previously Flask would generate its own 500 pages in response to uncaught exceptions; however, in doing so it would silence the exception. This meant that the middleware, critically including the session middleware, did not see exceptions. This was causing behaviour in which transactions were not actually rolling back after errors, leading to labels in deeply mysterious states.

Propagating the error up to gunicorn and letting gunicorn handle the generation of a 500 page, _after_ middleware, fixes this.