### PR TITLE
Improve test process wait

### DIFF
--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -144,12 +144,9 @@ def test_prometheus_logger_wipes_directory_on_startup(app):
 
 
 def test_prometheus_logger_metrics(routemaster_serve_subprocess):
-    with routemaster_serve_subprocess() as (proc, port):
-        while True:
-            out = proc.stdout.readline()
-            if 'Booting worker' in out.decode('utf-8'):
-                break
-
+    with routemaster_serve_subprocess(
+        wait_for_output=b'Booting worker',
+    ) as (proc, port):
         # Populate metrics with a request
         requests.get(f'http://127.0.0.1:{port}/')
 
@@ -165,12 +162,9 @@ def test_prometheus_logger_metrics(routemaster_serve_subprocess):
 
 
 def test_prometheus_logger_ignores_metrics_path(routemaster_serve_subprocess):
-    with routemaster_serve_subprocess() as (proc, port):
-        while True:
-            out = proc.stdout.readline()
-            if 'Booting worker' in out.decode('utf-8'):
-                break
-
+    with routemaster_serve_subprocess(
+        wait_for_output=b'Booting worker',
+    ) as (proc, port):
         # This should _not_ populate the metrics with any samples
         requests.get(f'http://127.0.0.1:{port}/metrics')
 

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -532,7 +532,7 @@ def routemaster_serve_subprocess(unused_tcp_port):
     """
 
     @contextlib.contextmanager
-    def _inner():
+    def _inner(*, wait_for_output=None):
         env = os.environ.copy()
         env.update({
             'DB_HOST': os.environ.get('PG_HOST', 'localhost'),
@@ -556,6 +556,13 @@ def routemaster_serve_subprocess(unused_tcp_port):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
+
+            if wait_for_output is not None:
+                while True:
+                    out_line = proc.stdout.readline()
+                    if wait_for_output in out_line:
+                        break
+
             yield proc, unused_tcp_port
         finally:
             proc.terminate()

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -558,10 +558,15 @@ def routemaster_serve_subprocess(unused_tcp_port):
             )
 
             if wait_for_output is not None:
+                all_output = b''
                 while True:
+                    assert proc.poll() is None, all_output.decode('utf-8')
+
                     out_line = proc.stdout.readline()
                     if wait_for_output in out_line:
                         break
+
+                    all_output += out_line
 
             yield proc, unused_tcp_port
         finally:


### PR DESCRIPTION
Push the waiting logic into `routemaster_serve_subprocess` so it can use knowledge of the way the outputs are redirected and introduce checks on whether the underlying process has exited.

This allows the fixture to output a useful error message when the underlying process has errored for some reason, allowing the developer to debug that error.

This doesn't cover the case where the process has started but hasn't emitted the line we're testing for, though that has not been observed to be an issue.