### PR TITLE
Command line args to make local running easier

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -136,6 +136,14 @@ There are 3 types of trigger:
  - **Time** — triggers each day at the given time.
  - **Interval** — triggers every given interval (i.e. 1 hour, 5 minutes)
 
+NOTE: if routemaster is down when a trigger would have fired then it won't fire.
+e.g. If you have a trigger of:
+```
+- time: 18h00m
+```
+Then this condition won't be evaluated if routemaster is down at 6PM. It doesn't persistently track
+that it has triggers upcoming to evaluate, so in this case the condition would next be evaluated at
+the next time that routemaster is up at 6PM. 
 
 ### Data feeds
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -142,7 +142,7 @@ e.g. If you have a trigger of:
 - time: 18h00m
 ```
 Then this condition won't be evaluated if routemaster is down at 6PM. It doesn't persistently track
-that it has triggers upcoming to evaluate, so in this case the condition would next be evaluated at
+that it has triggers upcoming to evaluate, so in this case the condition would be evaluated at
 the next time that routemaster is up at 6PM. 
 
 ### Data feeds

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -1,5 +1,11 @@
 # Hacking on Routemaster
 
+First, ensure you have a user named `routemaster` in your local postgres, i.e. on your
+local psql execute:
+```
+CREATE USER routemaster;
+```
+
 You'll need to create a database for developing against and for running tests
 against. This can be done by running the `scripts/database/create_databases.sh`
 script. Full details of how the database, models & migrations are handled can

--- a/routemaster/app.py
+++ b/routemaster/app.py
@@ -23,13 +23,16 @@ class App(threading.local):
     logger: BaseLogger
     _current_session: Optional[Session]
     _webhook_runners: Dict[str, WebhookRunner]
+    use_local_urls: bool
 
     def __init__(
         self,
         config: Config,
+        use_local_urls: bool=False,
     ) -> None:
         """Initialisation of the app state."""
         self.config = config
+        self.use_local_urls = use_local_urls
         self.initialise()
 
     def initialise(self):
@@ -51,7 +54,7 @@ class App(threading.local):
         # Webhook runners may choose to persist a session, so we instantiate
         # up-front to ensure we re-use state.
         self._webhook_runners = {
-            x: webhook_runner_for_state_machine(y)
+            x: webhook_runner_for_state_machine(y, self.use_local_urls)
             for x, y in self.config.state_machines.items()
         }
 

--- a/routemaster/app.py
+++ b/routemaster/app.py
@@ -1,7 +1,7 @@
 """Core App singleton that holds state for the application."""
 import threading
 import contextlib
-from typing import Dict, Optional, Iterable
+from typing import Dict, Iterable, Optional
 
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.engine import Engine
@@ -15,7 +15,7 @@ from routemaster.webhooks import (
 )
 
 
-def only_python_logger(logger_configs: Iterable):
+def _only_python_logger(logger_configs: Iterable):
     return [x for x in logger_configs if 'PythonLogger' in x.dotted_path]
 
 
@@ -51,7 +51,7 @@ class App(threading.local):
         """
         self._db = initialise_db(self.config.database)
         logging_plugins = (
-            only_python_logger(self.config.logging_plugins) 
+            _only_python_logger(self.config.logging_plugins)
             if self.only_python_logging
             else self.config.logging_plugins
         )

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     '--only-python-logging',
-    help="For local testing, don't instantiate loggers other than the basic PythonLogger",
+    help="For local testing, only instantiate the basic PythonLogger plugin",
     default=False,
     is_flag=True,
 )

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -23,8 +23,14 @@ logger = logging.getLogger(__name__)
     type=click.File(encoding='utf-8'),
     required=True,
 )
+@click.option(
+    '--local',
+    help="Override webhook URLs to point to localhost",
+    default=False,
+    is_flag=True,
+)
 @click.pass_context
-def main(ctx, config_file):
+def main(ctx, config_file, local):
     """Shared entrypoint configuration."""
     logging.getLogger('schedule').setLevel(logging.CRITICAL)
 
@@ -34,7 +40,7 @@ def main(ctx, config_file):
         logger.exception("Configuration Error")
         click.get_current_context().exit(1)
 
-    ctx.obj = App(config)
+    ctx.obj = App(config, use_local_urls=local)
     _validate_config(ctx.obj)
 
 

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -29,8 +29,14 @@ logger = logging.getLogger(__name__)
     default=False,
     is_flag=True,
 )
+@click.option(
+    '--only-python-logging',
+    help="For local testing, don't instantiate loggers other than the basic PythonLogger",
+    default=False,
+    is_flag=True,
+)
 @click.pass_context
-def main(ctx, config_file, local):
+def main(ctx, config_file, local, only_python_logging):
     """Shared entrypoint configuration."""
     logging.getLogger('schedule').setLevel(logging.CRITICAL)
 
@@ -40,7 +46,11 @@ def main(ctx, config_file, local):
         logger.exception("Configuration Error")
         click.get_current_context().exit(1)
 
-    ctx.obj = App(config, use_local_urls=local)
+    ctx.obj = App(
+        config,
+        use_local_urls=local,
+        only_python_logging=only_python_logging,
+    )
     _validate_config(ctx.obj)
 
 

--- a/routemaster/config/loader.py
+++ b/routemaster/config/loader.py
@@ -145,6 +145,7 @@ def _load_webhook(yaml: Yaml) -> Webhook:
     return Webhook(
         match=re.compile(yaml['match']),
         headers=yaml['headers'],
+        localport=yaml.get('localport'),
     )
 
 

--- a/routemaster/config/model.py
+++ b/routemaster/config/model.py
@@ -10,6 +10,7 @@ from typing import (
     Mapping,
     Pattern,
     Iterable,
+    Optional,
     Sequence,
     NamedTuple,
 )
@@ -162,6 +163,7 @@ class Webhook(NamedTuple):
     """Configuration for webdook requests."""
     match: Pattern
     headers: Dict[str, str]
+    localport: Optional[int]
 
 
 class StateMachine(NamedTuple):

--- a/routemaster/config/schema.yaml
+++ b/routemaster/config/schema.yaml
@@ -34,7 +34,9 @@ properties:
                 type: string
               headers:
                 type: object
-            additionalProperties: false
+            additionalProperties:
+              localport:
+                type: integer
         states:
           title: States
           type: array

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -93,6 +93,7 @@ def test_realistic_config():
                         headers={
                             'x-api-key': 'Rahfew7eed1ierae0moa2sho3ieB1et3ohhum0Ei',
                         },
+                        localport=None,
                     ),
                 ],
                 states=[
@@ -300,6 +301,7 @@ def test_environment_variables_override_config_file_for_database_config():
                         headers={
                             'x-api-key': 'Rahfew7eed1ierae0moa2sho3ieB1et3ohhum0Ei',
                         },
+                        localport=None,
                     ),
                 ],
                 states=[

--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -71,6 +71,7 @@ TEST_STATE_MACHINES = {
                 headers={
                     'x-api-key': 'Rahfew7eed1ierae0moa2sho3ieB1et3ohhum0Ei',
                 },
+                localport=None,
             ),
         ],
         states=[

--- a/routemaster/logging/plugins.py
+++ b/routemaster/logging/plugins.py
@@ -12,11 +12,12 @@ class PluginConfigurationException(Exception):
 
 def register_loggers(
     config: Config,
-    logger_configs: Iterable[LoggingPluginConfig],
+    logger_configs: Iterable[LoggingPluginConfig]=None,
 ):
     """
     Iterate through all plugins in the config file and instatiate them.
     """
+    logger_configs = logger_configs or config.logging_plugins
     return [_import_logger(config, x) for x in logger_configs]
 
 

--- a/routemaster/logging/plugins.py
+++ b/routemaster/logging/plugins.py
@@ -1,5 +1,6 @@
 """Plugin loading and configuration."""
 import importlib
+from typing import Iterable
 
 from routemaster.config import Config, LoggingPluginConfig
 from routemaster.logging.base import BaseLogger
@@ -9,11 +10,14 @@ class PluginConfigurationException(Exception):
     """Raised to signal an invalid plugin that was loaded."""
 
 
-def register_loggers(config: Config):
+def register_loggers(
+    config: Config,
+    logger_configs: Iterable[LoggingPluginConfig],
+):
     """
     Iterate through all plugins in the config file and instatiate them.
     """
-    return [_import_logger(config, x) for x in config.logging_plugins]
+    return [_import_logger(config, x) for x in logger_configs]
 
 
 def _import_logger(

--- a/routemaster/webhooks.py
+++ b/routemaster/webhooks.py
@@ -1,8 +1,8 @@
 """Webhook invocation."""
 
 import enum
-from urllib.parse import urlparse, urlunparse
 from typing import Any, Dict, Callable, Iterable
+from urllib.parse import urlparse, urlunparse
 
 import requests
 
@@ -28,7 +28,11 @@ class RequestsWebhookRunner(object):
     Optionally takes a list of webhook configs to modify how requests are made.
     """
 
-    def __init__(self, webhook_configs: Iterable[Webhook]=(), url_builder: Callable[[str], str]=(lambda x: x)) -> None:
+    def __init__(
+        self,
+        webhook_configs: Iterable[Webhook]=(),
+        url_builder: Callable[[str], str]=(lambda x: x),
+    ) -> None:
         # Use a session so that we can take advantage of connection pooling in
         # `urllib3`.
         self.session = requests.Session()
@@ -68,8 +72,6 @@ class RequestsWebhookRunner(object):
         else:
             return WebhookResult.RETRY
 
-    
-
     def _headers_for_url(self, url: str) -> Dict[str, Any]:
         headers = {}
         for config in self.webhook_configs:
@@ -78,16 +80,16 @@ class RequestsWebhookRunner(object):
         return headers
 
 
-def to_local_scheme_netloc(scheme: str, netloc: str) -> tuple:
+def _to_local_scheme_netloc(scheme: str, netloc: str) -> tuple:
     if 'thread.com' in netloc:
         return ('http', 'localhost:8000')
     else:
         return (scheme, netloc)
 
 
-def to_local_url(url: str) -> str:
+def _to_local_url(url: str) -> str:
     parts = urlparse(url)
-    mapped_url = to_local_scheme_netloc(*parts[:2]) + parts[2:6]
+    mapped_url = _to_local_scheme_netloc(*parts[:2]) + parts[2:6]
     return urlunparse(mapped_url)
 
 
@@ -101,6 +103,6 @@ def webhook_runner_for_state_machine(
     Applies any state machine configuration to the runner.
     """
     if only_use_localhost:
-        return RequestsWebhookRunner(state_machine.webhooks, to_local_url)
-    
+        return RequestsWebhookRunner(state_machine.webhooks, _to_local_url)
+
     return RequestsWebhookRunner(state_machine.webhooks)

--- a/routemaster/webhooks.py
+++ b/routemaster/webhooks.py
@@ -1,6 +1,7 @@
 """Webhook invocation."""
 
 import enum
+from urllib.parse import urlparse, urlunparse
 from typing import Any, Dict, Callable, Iterable
 
 import requests
@@ -27,11 +28,12 @@ class RequestsWebhookRunner(object):
     Optionally takes a list of webhook configs to modify how requests are made.
     """
 
-    def __init__(self, webhook_configs: Iterable[Webhook]=()) -> None:
+    def __init__(self, webhook_configs: Iterable[Webhook]=(), url_builder: Callable[[str], str]=(lambda x: x)) -> None:
         # Use a session so that we can take advantage of connection pooling in
         # `urllib3`.
         self.session = requests.Session()
         self.webhook_configs = webhook_configs
+        self.url_builder = url_builder
 
     def __call__(
         self,
@@ -50,7 +52,7 @@ class RequestsWebhookRunner(object):
 
         try:
             result = self.session.post(
-                url,
+                self.url_builder(url),
                 data=data,
                 headers=headers,
                 timeout=10,
@@ -66,6 +68,8 @@ class RequestsWebhookRunner(object):
         else:
             return WebhookResult.RETRY
 
+    
+
     def _headers_for_url(self, url: str) -> Dict[str, Any]:
         headers = {}
         for config in self.webhook_configs:
@@ -74,12 +78,29 @@ class RequestsWebhookRunner(object):
         return headers
 
 
+def to_local_scheme_netloc(scheme: str, netloc: str) -> tuple:
+    if 'thread.com' in netloc:
+        return ('http', 'localhost:8000')
+    else:
+        return (scheme, netloc)
+
+
+def to_local_url(url: str) -> str:
+    parts = urlparse(url)
+    mapped_url = to_local_scheme_netloc(*parts[:2]) + parts[2:6]
+    return urlunparse(mapped_url)
+
+
 def webhook_runner_for_state_machine(
     state_machine: StateMachine,
+    only_use_localhost=False,
 ) -> WebhookRunner:
     """
     Create the webhook runner for a given state machine.
 
     Applies any state machine configuration to the runner.
     """
+    if only_use_localhost:
+        return RequestsWebhookRunner(state_machine.webhooks, to_local_url)
+    
     return RequestsWebhookRunner(state_machine.webhooks)


### PR DESCRIPTION
It can be tricky to use routemaster locally without hacking the config because:
- webhooks are contained in the config and typically point to production endpoints (e.g. https://www.example.com), so in order to avoid sending bogus requests to production services you typically find-replace in the config e.g. https://www.example.com -> http://localhost:8000
- certain logger pluggins e.g. prometheus / sentry also assume that routemaster runs in a production-like setting - you typically remove these loggers from the config in order to run locally

This change adds command line options & associated config to workaround these issues and make running locally possible without hacking config in these ways, specifically:
1. add a command-line option `--local` which looks for a newly added `localport` setting in the webhooks config items
   - when `--local` is set and the webhook called matches a given webhook config that has a `localport` setting, the URL is overridden to use HTTP scheme and a netloc of `'localhost:{0}'.format(x)` where x is the value of `localport` in the config
1. add a command-line option `--python-logging-only` which skips instantiation of any loggers that are not the basic routemaster PythonLogger, so the advanced loggers will not be used

This has been tested manually. I'm not sure that the webhooks config is the ideal place for this - it seems like there may be an alternative that's higher up the config tree and a bit more specific to this case. Also, I'm open to suggestions for alternative names of these options if people don't think the names are helpful.