### PR TITLE
Pin to a slightly older version of jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=(
         'click',
         'pyyaml',
-        'jsonschema >=2.6',
+        'jsonschema >=2.6, <3',
         'flask',
         'psycopg2-binary',
         'sqlalchemy',


### PR DESCRIPTION
I'm not completely clear what actually changed in v3.0, however it does start failing our tests. This is the simplest fix for now.