### PR TITLE
Timezone processing logging

### DIFF
--- a/routemaster/cron_processors.py
+++ b/routemaster/cron_processors.py
@@ -69,6 +69,7 @@ class TimezoneAwareProcessor:
         self.processor()
 
     def __repr__(self) -> str:
+        """Return a useful debug representation."""
         return (
             f'<TimezoneAwareProcessor: {self.trigger.time} in '
             f'{self.trigger.timezone}>'
@@ -117,6 +118,7 @@ class MetadataTimezoneAwareProcessor:
         self.processor(label_provider=label_provider)
 
     def __repr__(self) -> str:
+        """Return a useful debug representation."""
         return (
             f'<MetadataTimezoneAwareProcessor: {self.trigger.time} for '
             f'{self.trigger.timezone_metadata_path}>'

--- a/routemaster/cron_processors.py
+++ b/routemaster/cron_processors.py
@@ -52,6 +52,12 @@ class TimezoneAwareProcessor:
 
         self.processor()
 
+    def __repr__(self) -> str:
+        return (
+            f'<TimezoneAwareProcessor: {self.trigger.time} in '
+            f'{self.trigger.timezone}>'
+        )
+
 
 class MetadataTimezoneAwareProcessor:
     """
@@ -84,3 +90,9 @@ class MetadataTimezoneAwareProcessor:
         )
 
         self.processor(label_provider=label_provider)
+
+    def __repr__(self) -> str:
+        return (
+            f'<MetadataTimezoneAwareProcessor: {self.trigger.time} for '
+            f'{self.trigger.timezone_metadata_path}>'
+        )

--- a/routemaster/tests/test_cron_processors.py
+++ b/routemaster/tests/test_cron_processors.py
@@ -16,6 +16,16 @@ from routemaster.cron_processors import (
 # Test TimezoneAwareProcessor
 
 
+def test_timezone_aware_processor_repr() -> None:
+    mock_callable = mock.Mock()
+    trigger = TimezoneAwareTrigger(datetime.time(12, 0), 'Etc/UTC')
+
+    processor = TimezoneAwareProcessor(mock_callable, trigger)
+
+    assert 'Etc/UTC' in repr(processor)
+    assert '12:00' in repr(processor)
+
+
 @freezegun.freeze_time('2019-08-01 12:00 UTC')
 def test_timezone_aware_processor_runs_on_time() -> None:
     mock_callable = mock.Mock()
@@ -61,6 +71,16 @@ def test_timezone_aware_processor_doesnt_run_at_wrong_time() -> None:
 
 
 # Test MetadataTimezoneAwareProcessor
+
+
+def test_metadata_timezone_aware_processor_repr() -> None:
+    mock_callable = mock.Mock()
+    trigger = MetadataTimezoneAwareTrigger(datetime.time(12, 0), ['tz'])
+
+    processor = MetadataTimezoneAwareProcessor(mock_callable, trigger)
+
+    assert 'tz' in repr(processor)
+    assert '12:00' in repr(processor)
 
 
 @freezegun.freeze_time('2019-01-01 12:00 UTC')


### PR DESCRIPTION
Adds logging around when the timezone aware cron processors run.
This aims to help diagnose observed delays in labels moving between states.