### PR TITLE
Proposal for `restore_label_and_restart` functionality

### DIFF
--- a/routemaster/conftest.py
+++ b/routemaster/conftest.py
@@ -373,13 +373,17 @@ def delete_label(app):
 
 
 @pytest.fixture()
-def create_deleted_label(create_label, delete_label):
+def create_deleted_label(create_label, delete_label, metadata={}):
     """
     Create a label in the database and then delete it.
     """
 
-    def _create_and_delete(name: str, state_machine_name: str) -> LabelRef:
-        create_label(name, state_machine_name, {})
+    def _create_and_delete(
+        name: str,
+        state_machine_name: str,
+        metadata: dict = {},
+    ) -> LabelRef:
+        create_label(name, state_machine_name, metadata)
         delete_label(name, state_machine_name)
         return LabelRef(name, state_machine_name)
 

--- a/routemaster/server/endpoints.py
+++ b/routemaster/server/endpoints.py
@@ -157,10 +157,20 @@ def create_label(state_machine_name, label_name):
     try:
         initial_state_name = \
             app.config.state_machines[state_machine_name].states[0].name
-        metadata = state_machine.create_label(app, label, initial_metadata)
+        if 'restore_label_and_restart' in data:
+            metadata = state_machine.restore_label_and_restart(
+                app,
+                label,
+                initial_metadata,
+            )
+        else:
+            metadata = state_machine.create_label(app, label, initial_metadata)
         return jsonify(metadata=metadata, state=initial_state_name), 201
     except LookupError:
         msg = f"State machine '{state_machine_name}' does not exist"
+        abort(404, msg)
+    except UnknownLabel:
+        msg = f"Label '{label}' does not exist"
         abort(404, msg)
     except LabelAlreadyExists:
         msg = f"Label {label_name} already exists in '{state_machine_name}'"

--- a/routemaster/server/tests/test_endpoints.py
+++ b/routemaster/server/tests/test_endpoints.py
@@ -326,16 +326,14 @@ def test_create_label_409_for_deleted_label(client, create_label):
     assert response.status_code == 409
 
 
-def test_restore_label(app, client, create_label, delete_label):
-    create_label('foo', 'test_machine', {})
-    delete_label('foo', 'test_machine')
+def test_restore_label(app, client, create_deleted_label):
+    create_deleted_label('foo', 'test_machine', {'foo': 'bar'})
 
     label_metadata = {'bar': 'baz'}
     response = client.post(
-        '/state-machines/test_machine/labels/foo',
+        '/state-machines/test_machine/labels/foo/restore_and_restart',
         data=json.dumps({
             'metadata': label_metadata,
-            'restore_label_and_restart': True,
         }),
         content_type='application/json',
     )
@@ -349,12 +347,11 @@ def test_restore_label(app, client, create_label, delete_label):
         assert label.deleted is False
 
 
-def test_restore_unknown_label(client, create_label):
+def test_restore_unknown_label(client):
     response = client.post(
-        '/state-machines/test_machine/labels/foo',
+        '/state-machines/test_machine/labels/foo/restore_and_restart',
         data=json.dumps({
             'metadata': {},
-            'restore_label_and_restart': True,
         }),
         content_type='application/json',
     )

--- a/routemaster/state_machine/__init__.py
+++ b/routemaster/state_machine/__init__.py
@@ -10,6 +10,7 @@ from routemaster.state_machine.api import (
     process_cron,
     get_label_state,
     get_label_metadata,
+    restore_label_and_restart,
     update_metadata_for_label,
 )
 from routemaster.state_machine.gates import process_gate
@@ -44,6 +45,7 @@ __all__ = (
     'LabelStateProcessor',
     'UnknownStateMachine',
     'update_metadata_for_label',
+    'restore_label_and_restart',
     'labels_in_state_with_metadata',
     'labels_needing_metadata_update_retry_in_gate',
 )

--- a/routemaster/state_machine/api.py
+++ b/routemaster/state_machine/api.py
@@ -113,7 +113,7 @@ def restore_label_and_restart(
 
     # Record the label as having been restored and add its initial metadata
     if not row.deleted:
-        raise AssertionError(f"Label {label} is not marked as deleted!")
+        raise LabelAlreadyExists(f"Label {label} is not marked as deleted!")
 
     row.metadata = replacement_metadata
     row.deleted = False
@@ -122,7 +122,7 @@ def restore_label_and_restart(
     current_state = get_current_state(app, label, state_machine)
 
     if current_state is not None:
-        raise AssertionError(f"Deleted label {label} has current state!")
+        raise LabelAlreadyExists(f"Deleted label {label} has current state!")
 
     row.history.append(History(
         old_state=None,

--- a/routemaster/state_machine/api.py
+++ b/routemaster/state_machine/api.py
@@ -106,7 +106,14 @@ def restore_label_and_restart(
     label: LabelRef,
     replacement_metadata: Metadata,
 ) -> Metadata:
-    """Restores a label that was previously deleted."""
+    """
+    Restores a label that was previously deleted.
+
+    We replace the metadata entirely rather than merging it, so as to prevent
+    old and stale data remaining in the system longer than it needs to. This
+    function restarting the label into a completely fresh state cuts down on
+    the number of possible states a label can exist in.
+    """
     state_machine = get_state_machine(app, label)
 
     row = lock_label(app, label)

--- a/routemaster/state_machine/tests/test_state_machine.py
+++ b/routemaster/state_machine/tests/test_state_machine.py
@@ -10,6 +10,7 @@ from routemaster.state_machine import (
     LabelRef,
     DeletedLabel,
     UnknownLabel,
+    LabelAlreadyExists,
     UnknownStateMachine,
 )
 from routemaster.state_machine.gates import process_gate
@@ -399,7 +400,7 @@ def test_restore_undeleted_label(app, assert_history, mock_test_feed):
         state_machine.create_label(app, label_foo, {})
 
     with app.new_session():
-        with pytest.raises(AssertionError):
+        with pytest.raises(LabelAlreadyExists):
             state_machine.restore_label_and_restart(
                 app,
                 label_foo,


### PR DESCRIPTION
Currently there is no API to allow restoring a label, once deleted.

This is PR adds in an API to allow restoring a label, if it's been deleted, restarting the label to the initial state machine state, and taking the metadata specified