### PR TITLE
Ensure history entries have a consistent 'created' time

### DIFF
--- a/routemaster/state_machine/actions.py
+++ b/routemaster/state_machine/actions.py
@@ -4,8 +4,6 @@ import json
 import hashlib
 import functools
 
-from sqlalchemy import func
-
 from routemaster.db import History
 from routemaster.app import App
 from routemaster.utils import template_url

--- a/routemaster/state_machine/actions.py
+++ b/routemaster/state_machine/actions.py
@@ -90,7 +90,6 @@ def process_action(
     app.session.add(History(
         label_state_machine=state_machine.name,
         label_name=label.name,
-        created=func.now(),
         old_state=action.name,
         new_state=next_state.name,
     ))

--- a/routemaster/state_machine/gates.py
+++ b/routemaster/state_machine/gates.py
@@ -63,7 +63,6 @@ def process_gate(
     app.session.add(History(
         label_state_machine=state_machine.name,
         label_name=label.name,
-        created=func.now(),
         old_state=gate.name,
         new_state=destination.name,
     ))

--- a/routemaster/state_machine/gates.py
+++ b/routemaster/state_machine/gates.py
@@ -1,6 +1,4 @@
 """Processing for gate states."""
-from sqlalchemy import func
-
 from routemaster.db import Label, History
 from routemaster.app import App
 from routemaster.config import Gate, State, StateMachine


### PR DESCRIPTION
Previously some history entries were created using the field default (which was calculated in Python) while others were created using the SQL `now()` function. This change ensures that they all use the field default; ensuring consistency and correct ordering.

Fixes https://github.com/thread/routemaster/issues/89