### PR TITLE
Use layer-loader to enable overridable values in configs

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -5,6 +5,7 @@ Use with `python -i dev.py` for a useful interactive shell.
 """
 
 import yaml
+import layer_loader
 
 from routemaster.db import *  # noqa: F403, F401
 from routemaster.app import App
@@ -17,8 +18,12 @@ def app_from_config(config_path):
 
     By default, will use the example.yaml file.
     """
-    with open(config_path, 'r') as f:
-        config = load_config(yaml.load(f))
+    config = load_config(
+        layer_loader.load_files(
+            [config_path],
+            loader=yaml.load,
+        ),
+    )
 
     class InteractiveApp(App):
         """

--- a/example.yaml
+++ b/example.yaml
@@ -19,19 +19,19 @@ state_machines:
               state: send_welcome_email_test
 
       - action: send_welcome_email
-        webhook: https://www.thread.com/hooks/user-emails/send_welcome_email
+        webhook: '{placeholders.api_root}/user-emails/send_welcome_email'
         next:
           type: constant
           state: generate_first_recs
 
       - action: send_welcome_email_test
-        webhook: https://www.thread.com/hooks/user-emails/send_welcome_email_test
+        webhook: '{placeholders.api_root}/user-emails/send_welcome_email_test'
         next:
           type: constant
           state: generate_first_recs
 
       - action: generate_first_recs
-        webhook: https://www.thread.com/hooks/user-emails/generate_first_recs
+        webhook: '{placeholders.api_root}/user-emails/generate_first_recs'
         next:
           type: constant
           state: wait_for_first_recs
@@ -51,13 +51,13 @@ state_machines:
               state: send_stylist_onboarding_email_test
 
       - action: send_stylist_onboarding_email
-        webhook: https://www.thread.com/hooks/user-emails/send_stylist_onboarding_email
+        webhook: '{placeholders.api_root}/user-emails/send_stylist_onboarding_email'
         next:
           type: constant
           state: wait_before_browse_email
 
       - action: send_stylist_onboarding_email_test
-        webhook: https://www.thread.com/hooks/user-emails/send_stylist_onboarding_email_test
+        webhook: '{placeholders.api_root}/user-emails/send_stylist_onboarding_email_test'
         next:
           type: constant
           state: wait_before_browse_email
@@ -72,7 +72,7 @@ state_machines:
           state: send_browse_email
 
       - action: send_browse_email
-        webhook: https://www.thread.com/hooks/user-emails/send_browse_email
+        webhook: '{placeholders.api_root}/user-emails/send_browse_email'
         next:
           type: constant
           state: end
@@ -94,3 +94,7 @@ plugins:
     - class: routemaster_sentry:SentryLogger
       kwargs:
         dsn: https://xxxxxxx:xxxxxxx@sentry.io/xxxxxxx
+
+
+placeholders:
+  api_root: https://www.thread.com/hooks

--- a/routemaster/cli.py
+++ b/routemaster/cli.py
@@ -3,6 +3,7 @@ import logging
 
 import yaml
 import click
+import layer_loader
 
 from routemaster.app import App
 from routemaster.cron import CronThread
@@ -19,17 +20,24 @@ logger = logging.getLogger(__name__)
 @click.option(
     '-c',
     '--config-file',
+    'config_files',
     help="Path to the service config file.",
     type=click.File(encoding='utf-8'),
     required=True,
+    multiple=True,
 )
 @click.pass_context
-def main(ctx, config_file):
+def main(ctx, config_files):
     """Shared entrypoint configuration."""
     logging.getLogger('schedule').setLevel(logging.CRITICAL)
 
+    config_data = layer_loader.load_files(
+        config_files,
+        loader=yaml.load,
+    )
+
     try:
-        config = load_config(yaml.load(config_file))
+        config = load_config(config_data)
     except ConfigError:
         logger.exception("Configuration Error")
         click.get_current_context().exit(1)

--- a/routemaster/config/schema.yaml
+++ b/routemaster/config/schema.yaml
@@ -170,6 +170,14 @@ properties:
           required:
             - class
           additionalProperties: false
+  # A root element for placeholders which can be overriden within the layers of
+  # configuration files. Since these end up in the structure but are ignored,
+  # the schema needs to allow them to exist though cannot describe the children
+  # of the node in detail.
+  placeholders:
+    type: object
+    additionalProperties:
+      type: string
 required:
   - state_machines
 additionalProperties: false

--- a/routemaster/config/tests/test_loading.py
+++ b/routemaster/config/tests/test_loading.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import yaml
 import pytest
+import layer_loader
 
 from routemaster.config import (
     Gate,
@@ -427,7 +428,12 @@ def test_example_config_loads():
 
     assert example_yaml.exists(), "Example file is missing! (is this test set up correctly?)"
 
-    example_config = load_config(yaml.load(example_yaml.read_text()))
+    example_config = load_config(
+        layer_loader.load_files(
+            [example_yaml],
+            loader=yaml.load,
+        ),
+    )
 
     # Some basic assertions that we got the right thing loaded
     assert list(example_config.state_machines.keys()) == ['user_lifecycle']

--- a/routemaster/tests/test_validation.py
+++ b/routemaster/tests/test_validation.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import yaml
 import pytest
+import layer_loader
 
 from routemaster.config import (
     Gate,
@@ -216,7 +217,12 @@ def test_example_config_is_valid(app):
 
     assert example_yaml.exists(), "Example file is missing! (is this test set up correctly?)"
 
-    example_config = load_config(yaml.load(example_yaml.read_text()))
+    example_config = load_config(
+        layer_loader.load_files(
+            [example_yaml],
+            loader=yaml.load,
+        ),
+    )
 
     # quick check that we've loaded the config we expect
     assert list(example_config.state_machines.keys()) == ['user_lifecycle']

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
 
     install_requires=(
         'click',
+        'layer-loader',
         'pyyaml',
         'jsonschema >=2.6, <3',
         'flask',


### PR DESCRIPTION
This uses https://pypi.org/project/layer-loader/ to allow configurations to be separated into separate files and to have placeholders defined which other files can easily override.

In order to support using placeholders, we need to add a new entry in the schema. This new entry allows a root `placeholders' key to be present in the configuration dict, though this value is always ignored.