### PR TITLE
Allow the readme to be included implicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,27 +18,36 @@ references:
     TOXENV: py36
     COVERALLS: true
 
+  # Set up a cached virtualenv in which to install our CI dependencies
+  restore-build-dependency-cache: &restore-build-dependency-cache
+    restore_cache:
+      name: Restore build dependency cache
+      key: deps-venv-{{ .Branch }}-{{ .Environment.CIRCLE_STAGE }}-{{ checksum ".circleci/requirements.txt" }}
+
+  install-build-dependencies: &install-build-dependencies
+    run:
+      name: Install build dependencies
+      command: |
+        python3 -m venv venv
+        . venv/bin/activate
+        pip install -r .circleci/requirements.txt
+
+  save-build-dependency-cache: &save-build-dependency-cache
+    save_cache:
+      name: Save build dependency cache
+      key: deps-venv-{{ .Branch }}-{{ .Environment.CIRCLE_STAGE }}-{{ checksum ".circleci/requirements.txt" }}
+      paths:
+        - "venv"
+
   test-template: &test-template
     working_directory: ~/routemaster
 
     steps:
       - checkout
 
-        # Set up a cached virtualenv in which to install tox
-      - restore_cache:
-          name: Restore build dependency cache
-          key: deps-venv-{{ .Branch }}-{{ .Environment.CIRCLE_STAGE }}-{{ checksum ".circleci/requirements.txt" }}
-      - run:
-          name: Install tox
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r .circleci/requirements.txt
-      - save_cache:
-          name: Save build dependency cache
-          key: deps-venv-{{ .Branch }}-{{ .Environment.CIRCLE_STAGE }}-{{ checksum ".circleci/requirements.txt" }}
-          paths:
-            - "venv"
+      - *restore-build-dependency-cache
+      - *install-build-dependencies
+      - *save-build-dependency-cache
 
       - run:
           name: Wait for Database with Dockerize
@@ -126,21 +135,11 @@ jobs:
       - image: circleci/python:3.6.3
     steps:
       - checkout
-      - restore_cache:
-          name: Restore build dependency cache
-          key: deps-venv-18.0-2.9.1
-      - run:
-          name: Install tox
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install pip==18.0
-            pip install tox==2.9.1
-      - save_cache:
-          name: Save build dependency cache
-          key: deps-venv-18.0-2.9.1
-          paths:
-            - "venv"
+
+      - *restore-build-dependency-cache
+      - *install-build-dependencies
+      - *save-build-dependency-cache
+
       - restore_cache:
           name: Restore .tox cache
           key: deps-tox-{{ checksum "scripts/linting/requirements.txt" }}
@@ -163,21 +162,11 @@ jobs:
       - image: circleci/python:3.6.3
     steps:
       - checkout
-      - restore_cache:
-          name: Restore build dependency cache
-          key: deps-venv-18.0-2.9.1
-      - run:
-          name: Install tox
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install pip==18.0
-            pip install tox==2.9.1
-      - save_cache:
-          name: Save build dependency cache
-          key: deps-venv-18.0-2.9.1
-          paths:
-            - "venv"
+
+      - *restore-build-dependency-cache
+      - *install-build-dependencies
+      - *save-build-dependency-cache
+
       - restore_cache:
           name: Restore .tox cache
           key: deps-tox-{{ checksum "scripts/typechecking/requirements.txt" }}

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for top level CI operations.
 # Don't include Routemaster's own requirements here.
-pip==18.0
+pip>=20
+setuptools>=46
 tox==2.9.1
 coveralls==1.10.0

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for top level CI operations.
 # Don't include Routemaster's own requirements here.
 pip==18.0
+setuptools>=36.4
 tox==2.9.1
 coveralls==1.10.0

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,6 +1,5 @@
 # Requirements for top level CI operations.
 # Don't include Routemaster's own requirements here.
-pip>=20
-setuptools>=46
+pip==18.0
 tox==2.9.1
 coveralls==1.10.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include README.md
 include version.py
 include routemaster/config/schema.yaml

--- a/plugins/routemaster-prometheus/MANIFEST.in
+++ b/plugins/routemaster-prometheus/MANIFEST.in
@@ -1,2 +1,1 @@
-include README.md
 include version.py

--- a/plugins/routemaster-sentry/MANIFEST.in
+++ b/plugins/routemaster-sentry/MANIFEST.in
@@ -1,2 +1,1 @@
-include README.md
 include version.py


### PR DESCRIPTION
I'm hoping that this will get PyPI to use the README data from the metadata rather than from the `README.md`, which will mean it will pick up that it's markdown and so (hopefully) render it correctly.

The README files still get included in the sdist, so at worst I think this removes a redundant mention of it in the `MANIFEST.in`.

The plugins have READMEs in reStructuredText anyway, so the mention of a `README.md` in their `MANIFEST.in` was likely causing weirdness anyway.