### PR TITLE
StatsD plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,11 @@ jobs:
             python setup.py bdist_wheel
             twine upload dist/*
 
+            cd plugins/routemaster-statsd
+            python setup.py sdist
+            python setup.py bdist_wheel
+            twine upload dist/*
+
       - setup_remote_docker
 
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY dist/ .
 # Install first-party plugins (inactive by default).
 COPY plugins/routemaster-sentry/dist/ .
 COPY plugins/routemaster-prometheus/dist/ .
+COPY plugins/routemaster-statsd/dist/ .
 
 RUN pip install --no-cache-dir *.whl
 

--- a/docs/logging_plugins.md
+++ b/docs/logging_plugins.md
@@ -54,6 +54,22 @@ plugins:
     - class: routemaster_prometheus.logger:PrometheusLogger
 ```
 
+### StatsD Logger
+
+The StatsD logger is also maintained in the Routemaster repo. It exports metrics to a provided statsd server over UDP.
+
+Several metrics about the behaviour and performance of Routemaster are
+exposed, including timings and status codes of the API, webhook requests and
+feed requests, as well as the processing of jobs in the internal cron system.
+
+
+```yaml
+plugins:
+  logging:
+    - class: routemaster_statsd.logger:StatsDLogger
+```
+
+The target StatsD server can be configured through the plugin keyword arguments or using the `STATSD_HOST` and `STATSD_PORT` environment variables.
 
 ## Implementing a logging plugin
 

--- a/example.yaml
+++ b/example.yaml
@@ -91,6 +91,13 @@ plugins:
       kwargs:
         path: /metrics
 
+    - class: routemaster_statsd:StatsDLogger
+      kwargs:
+        host: localhost
+        port: 8125
+        tags:
+          environment: production
+
     - class: routemaster_sentry:SentryLogger
       kwargs:
         dsn: https://xxxxxxx:xxxxxxx@sentry.io/xxxxxxx

--- a/plugins/routemaster-statsd/MANIFEST.in
+++ b/plugins/routemaster-statsd/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include version.py

--- a/plugins/routemaster-statsd/README.rst
+++ b/plugins/routemaster-statsd/README.rst
@@ -1,0 +1,23 @@
+
+routemaster-statsd
+^^^^^^^^^^^^^^^^^^
+
+Usage, in your Routemaster configuration file:
+
+.. code-block:: yaml
+
+   plugins:
+     logging:
+       - class: routemaster_statsd.logger:StatsDLogger
+         kwargs:
+           host: localhost
+           port: 8800
+           tags:
+             environment: production
+
+- This plugin will send metrics over UDP.
+- The host and port can also be specified through environment variable
+(`STATSD_HOST` and `STATSD_PORT`). The default is `localhost:8125`.
+- The statsd tags will be send in `Dogstatsd
+<https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/>`_'s format
+which is widely supported.

--- a/plugins/routemaster-statsd/routemaster_statsd/__init__.py
+++ b/plugins/routemaster-statsd/routemaster_statsd/__init__.py
@@ -1,0 +1,148 @@
+"""
+Statsd metrics exporter for Routemaster.
+
+This package provides a Routemaster logging plugin that pushes metrics to a
+Statsd server.
+"""
+import os
+import contextlib
+from timeit import default_timer as timer
+
+import statsd
+from werkzeug.routing import NotFound, RequestRedirect, MethodNotAllowed
+
+from routemaster.logging import BaseLogger
+
+DEFAULT_HOST = os.environ.get('STATSD_HOST', 'localhost')
+DEFAULT_PORT = int(os.environ.get('STATSD_PORT', 8125))
+
+
+class StatsDLogger(BaseLogger):
+    """Instruments Routemaster with Statsd."""
+
+    def __init__(
+        self,
+        *args,
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        namespace='routemaster',
+        tags=None,
+    ):
+        self.statsd = statsd.StatsdClient(
+            host=host,
+            port=int(port),
+            namespace=namespace,
+            tags=tags or {},
+        )
+        super().__init__(*args)
+
+    def init_flask(self, flask_app):
+        """Get routing information out of Flask."""
+        self.url_adapter = flask_app.url_map.bind('localhost')
+        self.endpoint_lookup = {
+            rule.endpoint: rule.rule
+            for rule in flask_app.url_map.iter_rules()
+        }
+
+    @contextlib.contextmanager
+    def process_cron(self, state_machine, state, fn_name):
+        """Send cron exceptions to Statsd."""
+        try:
+            yield
+        except Exception:
+            self.statsd.increment('exceptions', tags={'type': 'cron'})
+            raise
+        finally:
+            self.statsd.increment('cron_jobs_processed', tags={
+                'fn_name': fn_name,
+                'state_machine': state_machine.name,
+                'state': state.name,
+            })
+
+    @contextlib.contextmanager
+    def process_webhook(self, state_machine, state):
+        """Send webhook request exceptions to Statsd."""
+        try:
+            yield
+        except Exception:
+            self.statsd.increment('exceptions', tags={'type': 'webhook'})
+            raise
+
+    @contextlib.contextmanager
+    def process_feed(self, state_machine, state, feed_url):
+        """Send feed request exceptions to Statsd."""
+        try:
+            yield
+        except Exception:
+            self.statsd.increment('exceptions', tags={'type': 'feed'})
+            raise
+
+    def feed_response(
+        self,
+        state_machine,
+        state,
+        feed_url,
+        response,
+    ):
+        """Log feed response with status code to Statsd."""
+        self.statsd.increment('feed_requests', tags={
+            'feed_url': feed_url,
+            'state_machine': state_machine.name,
+            'state': state.name,
+            'status_code': response.status_code,
+        })
+
+    def webhook_response(
+        self,
+        state_machine,
+        state,
+        response,
+    ):
+        """Log webhook response with status code to Statsd."""
+        self.statsd.increment('webhook_requests', tags={
+            'state_machine': state_machine.name,
+            'state': state.name,
+            'status_code': response.status_code,
+        })
+
+    def process_request_started(self, environ):
+        """Start a timer."""
+        environ['_STATSD_REQUEST_TIMER'] = timer()
+
+    def process_request_finished(
+        self,
+        environ,
+        *,
+        status,
+        headers,
+        exc_info,
+    ):
+        """Log completed request metrics, given the timer we started."""
+        if exc_info:
+            self.statsd.increment('exceptions', tags={'type': 'api'})
+
+        total_time = max(
+            int(1000 * (timer() - environ['_STATSD_REQUEST_TIMER'])),
+            0,
+        )
+        path = environ['PATH_INFO']
+        method = environ['REQUEST_METHOD']
+
+        endpoint = ''
+
+        try:
+            match = self.url_adapter.match(path, method=method)
+            if match:
+                endpoint = self.endpoint_lookup[match[0]]
+        except (RequestRedirect, MethodNotAllowed, NotFound):
+            pass
+
+        self.statsd.timing(
+            'api_request_duration',
+            total_time,
+            tags={
+                'method': method,
+                'status': str(status),
+                'endpoint': endpoint,
+            },
+        )

--- a/plugins/routemaster-statsd/setup.py
+++ b/plugins/routemaster-statsd/setup.py
@@ -1,0 +1,43 @@
+"""Package setup."""
+
+import version
+from setuptools import setup, find_packages
+
+with open('README.rst', 'r', encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='routemaster_statsd',
+    version=version.get_version(),
+    url='https://github.com/thread/routemaster',
+    description="Statsd metrics reporting for Routemaster.",
+    long_description=long_description,
+
+    author="Thread",
+    author_email="tech@thread.com",
+
+    keywords=(
+    ),
+    license='MIT',
+
+    zip_safe=False,
+
+    packages=find_packages(),
+    include_package_data=True,
+
+    classifiers=(
+        'Development Status :: 2 - Pre-Alpha',
+        'Environment :: Console',
+        'Natural Language :: English',
+        'Operating System :: POSIX',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Office/Business',
+    ),
+
+    install_requires=(
+        'routemaster',
+        'statsd_python',
+    ),
+)

--- a/plugins/routemaster-statsd/version.py
+++ b/plugins/routemaster-statsd/version.py
@@ -1,0 +1,88 @@
+"""
+Versioning utils.
+"""
+
+__all__ = ('get_version')
+
+import os
+import re
+import logging
+import os.path
+import subprocess
+from os.path import dirname
+
+import pkg_resources
+
+version_re = re.compile('^Version: (.+)$', re.M)
+
+logger = logging.getLogger(__file__)
+
+
+def find_git_root(test):
+    prev, test = None, os.path.abspath(test)
+    while prev != test:
+        if os.path.isdir(os.path.join(test, '.git')):
+            return test
+        prev, test = test, os.path.abspath(os.path.join(test, os.pardir))
+    return None
+
+
+def get_version():
+    """
+    Gets the current version number.
+
+    If in a git repository, it is the current git tag.
+    Otherwise it is the one contained in the PKG-INFO file.
+    To use this script, simply import it in your setup.py file
+    and use the results of get_version() as your package version:
+        from version import *
+        setup(
+            ...
+            version=get_version(),
+            ...
+        )
+    """
+    git_root = find_git_root(dirname(__file__))
+
+    if git_root is not None:
+        # Get the version using "git describe".
+        cmd = 'git describe --tags --match [0-9]*'.split()
+        try:
+            version = subprocess.check_output(cmd).decode().strip()
+        except subprocess.CalledProcessError:
+            logger.exception('Unable to get version number from git tags')
+            exit(1)
+
+        # PEP 386 compatibility
+        if '-' in version:
+            version = '.post'.join(version.split('-')[:2])
+
+        # Don't declare a version "dirty" merely because a time stamp has
+        # changed. If it is dirty, append a ".dev1" suffix to indicate a
+        # development revision after the release.
+        with open(os.devnull, 'w') as fd_devnull:
+            subprocess.call(
+                ['git', 'status'],
+                stdout=fd_devnull,
+                stderr=fd_devnull,
+            )
+
+        cmd = 'git diff-index --name-only HEAD'.split()
+        try:
+            dirty = subprocess.check_output(cmd).decode().strip()
+        except subprocess.CalledProcessError:
+            logger.exception('Unable to get git index status')
+            exit(1)
+
+        if dirty != '':
+            version += '.dev1'
+
+        return version
+
+    else:
+        try:
+            return pkg_resources.working_set.by_key[
+                'routemaster_statsd'
+            ].version
+        except KeyError:
+            return '0.0.0-unreleased'

--- a/plugins/tests/test_logging_plugins.py
+++ b/plugins/tests/test_logging_plugins.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 from flask import Flask
 from routemaster_sentry import SentryLogger
+from routemaster_statsd import StatsDLogger
 from prometheus_client.core import Sample
 from routemaster_prometheus import PrometheusLogger
 from prometheus_client.parser import text_string_to_metric_families
@@ -19,10 +20,16 @@ SENTRY_KWARGS = {
 PROMETHEUS_KWARGS = {
     'path': '/metrics',
 }
+STATSD_KWARGS = {
+    'tags': {
+        'env': 'testing',
+    },
+}
 
 TEST_CASES: Iterable[Tuple[Type[BaseLogger], Dict[str, Any]]] = [
     (SentryLogger, SENTRY_KWARGS),
     (PrometheusLogger, PROMETHEUS_KWARGS),
+    (StatsDLogger, STATSD_KWARGS),
     (SplitLogger, {'loggers': [
         SentryLogger(None, **SENTRY_KWARGS),
         PrometheusLogger(None, **PROMETHEUS_KWARGS),

--- a/routemaster/config/schema.yaml
+++ b/routemaster/config/schema.yaml
@@ -166,7 +166,12 @@ properties:
               title: Logging plugin kwargs
               type: object
               additionalProperties:
-                type: string
+                anyOf:
+                  - type: string
+                  - type: integer
+                  - type: object
+                    additionalProperties:
+                      type: string
           required:
             - class
           additionalProperties: false

--- a/scripts/install_for_development
+++ b/scripts/install_for_development
@@ -1,3 +1,4 @@
 pip install -e .
 pip install -e ./plugins/routemaster-sentry
 pip install -e ./plugins/routemaster-prometheus
+pip install -e ./plugins/routemaster-statsd

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py36,py37,py38,py39,mypy,lint
 deps =
     -r{toxinidir}/scripts/testing/requirements.txt
     {toxinidir}/plugins/routemaster-prometheus
+    {toxinidir}/plugins/routemaster-statsd
     {toxinidir}/plugins/routemaster-sentry
 whitelist_externals =
     mkdir
@@ -22,7 +23,7 @@ commands =
     py.test -v \
       {posargs: \
         --cov=routemaster \
-        --cov=routemaster_prometheus \
+        --cov=routemaster_statsd \
         --cov=routemaster_sentry \
         --cov-report html:build/artifacts/coverage-{envname} \
         --junit-xml=build/results/testing-{envname}.xml \
@@ -33,6 +34,7 @@ commands =
 deps =
     -r{toxinidir}/scripts/typechecking/requirements.txt
     {toxinidir}/plugins/routemaster-prometheus
+    {toxinidir}/plugins/routemaster-statsd
     {toxinidir}/plugins/routemaster-sentry
 whitelist_externals =
     mkdir


### PR DESCRIPTION
This is a first pass at a Statsd plugin given the Prometheus integration has been unreliable and we're moving to statsd based collections in general.

I think it's mostly there, but I need to check CI and I'd like to add some tests if possible. Also, for clarity I did not want to pull in specifically `datadogpy` to remain generic and support other formats later if possible, but I coudn't find a good statsd client that supported tags so ended up hacking one around https://github.com/lirsacc/statsd_client_python. 

Ideally we'll run both for a bit and compare metrics.

The alternative to this would be to have Datadog or vector scrape the prometheus endpoint which is possible as well but a bit roundabout.