### PR TITLE
Fix schema definition to match code

### DIFF
--- a/routemaster/config/schema.yaml
+++ b/routemaster/config/schema.yaml
@@ -111,7 +111,7 @@ properties:
                       - type: object
                         properties:
                           type:
-                            const: 'metadata'
+                            const: 'context'
                           path: *dotted_path_definition
                           default:
                             type: string

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'click',
         'layer-loader',
         'pyyaml >= 5',
-        'jsonschema >=2.6, <3',
+        'jsonschema >=3, <5',
         'flask',
         'psycopg2-binary',
         'sqlalchemy',


### PR DESCRIPTION
This turns out to have had an incorrect value for a while, however the version of [`jsonschema`](https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst) being used didn't detect this as it didn't support Draft 6 of JSON Schema. Update the package to a more recent range which does support that.