### PR TITLE
Drop Python 3.6, default to running on 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
     PG_DB: routemaster
     PG_USER: routemaster
     PG_PASS: routemaster
-    TOXENV: py36
+    TOXENV: py37
     COVERALLS: true
 
   # Set up a cached virtualenv in which to install our CI dependencies
@@ -96,17 +96,6 @@ references:
             coveralls
 
 jobs:
-  test-36:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.6
-        environment:
-          <<: *steps-environment
-          TOXENV: py36
-          COVERALLS: true
-
-      - *postgres-container
-
   test-37:
     <<: *test-template
     docker:
@@ -147,14 +136,14 @@ jobs:
         environment:
           <<: *steps-environment
           TOXENV: py310
-          COVERALLS: false
+          COVERALLS: true
 
       - *postgres-container
 
   lint:
     working_directory: ~/routemaster
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.7
     steps:
       - checkout
 
@@ -164,7 +153,7 @@ jobs:
 
       - restore_cache:
           name: Restore .tox cache
-          key: deps-tox-1-{{ checksum "scripts/linting/requirements.txt" }}
+          key: deps-tox-2-{{ checksum "scripts/linting/requirements.txt" }}
       - run:
           name: Lint
           command: |
@@ -172,7 +161,7 @@ jobs:
             TOXENV=lint tox
       - save_cache:
           name: Save .tox cache
-          key: deps-tox-1-{{ checksum "scripts/linting/requirements.txt" }}
+          key: deps-tox-2-{{ checksum "scripts/linting/requirements.txt" }}
           paths:
             - ".tox"
       - store_test_results:
@@ -181,7 +170,7 @@ jobs:
   typecheck:
     working_directory: ~/routemaster
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.7
     steps:
       - checkout
 
@@ -191,7 +180,7 @@ jobs:
 
       - restore_cache:
           name: Restore .tox cache
-          key: deps-tox-1-{{ checksum "scripts/typechecking/requirements.txt" }}
+          key: deps-tox-2-{{ checksum "scripts/typechecking/requirements.txt" }}
       - run:
           name: Typecheck
           command: |
@@ -199,7 +188,7 @@ jobs:
             TOXENV=mypy tox
       - save_cache:
           name: Save .tox cache
-          key: deps-tox-1-{{ checksum "scripts/typechecking/requirements.txt" }}
+          key: deps-tox-2-{{ checksum "scripts/typechecking/requirements.txt" }}
           paths:
             - ".tox"
       - store_test_results:
@@ -208,7 +197,7 @@ jobs:
   release:
     working_directory: ~/routemaster
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.7
     steps:
       - checkout
 
@@ -275,10 +264,6 @@ workflows:
   version: 2
   build-release:
     jobs:
-      - test-36:
-          filters:
-            tags:
-              only: /.*/
       - test-37:
           filters:
             tags:
@@ -305,7 +290,6 @@ workflows:
               only: /.*/
       - release:
           requires:
-            - test-36
             - test-37
             - test-38
             - test-39

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-stretch
+FROM python:3.10-bullseye
 
 ENV PYTHONUNBUFFERED 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,mypy,lint
+envlist = py37,py38,py39,py310,mypy,lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.6 is well beyond end-of-life (December 2021). While 3.7 is still supported, it doesn't have long left (mid 2023). We should therefore still support using it, but there's no compelling reason to default to it.